### PR TITLE
Addition of support for the Kitty keyboard protocol.

### DIFF
--- a/examples/kitty_protocol.rs
+++ b/examples/kitty_protocol.rs
@@ -1,0 +1,78 @@
+use bevy::{
+    app::{AppExit, ScheduleRunnerPlugin},
+    prelude::*,
+};
+use bevy_ratatui::{
+    error::exit_on_error, event::KeyEvent, terminal::RatatuiContext, RatatuiPlugins,
+};
+
+fn main() {
+    let wait_duration = std::time::Duration::from_secs_f64(1. / 60.); // 60 FPS
+    App::new()
+        .init_resource::<LastKeypress>()
+        .add_plugins(RatatuiPlugins)
+        .add_plugins(ScheduleRunnerPlugin::run_loop(wait_duration))
+        .add_systems(PostStartup, setup_kitty_system)
+        .add_systems(PreUpdate, keyboard_input_system)
+        .add_systems(Update, draw_scene_system.pipe(exit_on_error))
+        .run();
+}
+
+#[derive(Resource)]
+struct KittyEnabled;
+
+#[derive(Resource, Default)]
+struct LastKeypress(pub Option<KeyEvent>);
+
+fn setup_kitty_system(mut commands: Commands, mut ratatui: ResMut<RatatuiContext>) {
+    if ratatui.enable_kitty_protocol().is_ok() {
+        commands.insert_resource(KittyEnabled);
+    }
+}
+
+fn draw_scene_system(
+    mut context: ResMut<RatatuiContext>,
+    kitty_enabled: Option<Res<KittyEnabled>>,
+    last_keypress: Res<LastKeypress>,
+) -> color_eyre::Result<()> {
+    context.draw(|frame| {
+        let mut text = ratatui::text::Text::raw(match kitty_enabled {
+            Some(_) => "Kitty protocol enabled!",
+            None => "Kitty protocol not supported in this terminal.",
+        });
+
+        text.push_line("Press any key. Press 'q' to Quit.");
+
+        if let Some(ref key_event) = last_keypress.0 {
+            let code_string = format!("{:?}", key_event.code);
+            let kind_string = match key_event.kind {
+                crossterm::event::KeyEventKind::Press => "pressed",
+                crossterm::event::KeyEventKind::Repeat => "repeated",
+                crossterm::event::KeyEventKind::Release => "released",
+            };
+            text.push_line("");
+            text.push_line(format!("{code_string} key was {kind_string}!"));
+        }
+
+        frame.render_widget(text.centered(), frame.size())
+    })?;
+    Ok(())
+}
+
+fn keyboard_input_system(
+    mut events: EventReader<KeyEvent>,
+    mut exit: EventWriter<AppExit>,
+    mut last_keypress: ResMut<LastKeypress>,
+) {
+    use crossterm::event::KeyCode;
+    for event in events.read() {
+        match event.code {
+            KeyCode::Char('q') | KeyCode::Esc => {
+                exit.send(AppExit);
+            }
+            _ => {
+                last_keypress.0 = Some(event.clone());
+            }
+        }
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -91,8 +91,11 @@ pub fn crossterm_event_system(
     while event::poll(Duration::ZERO)? {
         let event = event::read()?;
         match event {
-            Key(event) if event.kind == KeyEventKind::Press => {
-                if event.modifiers == KeyModifiers::CONTROL && event.code == KeyCode::Char('c') {
+            Key(event) => {
+                if event.kind == KeyEventKind::Press
+                    && event.modifiers == KeyModifiers::CONTROL
+                    && event.code == KeyCode::Char('c')
+                {
                     exit.send_default();
                 }
                 keys.send(KeyEvent(event));
@@ -112,7 +115,6 @@ pub fn crossterm_event_system(
             event::Event::Resize(columns, rows) => {
                 resize.send(ResizeEvent(Size::new(columns, rows)));
             }
-            _ => {}
         }
         events.send(CrosstermEvent(event));
     }

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -1,0 +1,60 @@
+use std::io::{self, stdout};
+
+use bevy::prelude::*;
+use crossterm::{
+    event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
+    terminal::supports_keyboard_enhancement,
+    ExecutableCommand,
+};
+
+pub struct KittyPlugin;
+
+impl Plugin for KittyPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, setup);
+    }
+}
+
+fn setup(mut commands: Commands) {
+    if enable_kitty_protocol().is_ok() {
+        commands.insert_resource(KittyEnabled);
+    }
+}
+
+#[derive(Resource)]
+pub struct KittyEnabled;
+
+impl Drop for KittyEnabled {
+    fn drop(&mut self) {
+        let _ = disable_kitty_protocol();
+    }
+}
+
+/// Enables support for the [kitty keyboard protocol]
+///
+/// Provides additional information involving keyboard events. For example, key release events will
+/// be reported.
+///
+/// Refer to the above link for a list of terminals that support the protocol. An `Ok` result is not
+/// a guarantee that all features are supported: you should have fallbacks that you use until you
+/// detect the event type you are looking for.
+///
+/// [kitty keyboard protocol]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+pub fn enable_kitty_protocol() -> io::Result<()> {
+    if supports_keyboard_enhancement()? {
+        stdout().execute(PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::all()))?;
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "Kitty keyboard protocol is not supported by this terminal.",
+    ))
+}
+
+/// Disables the [kitty keyboard protocol]
+///
+/// [kitty keyboard protocol]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+pub fn disable_kitty_protocol() -> io::Result<()> {
+    stdout().execute(PopKeyboardEnhancementFlags)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ use bevy::{app::PluginGroupBuilder, prelude::*};
 
 pub mod error;
 pub mod event;
+pub mod kitty;
 pub mod terminal;
 
 /// A plugin group that includes all the plugins in the Ratatui crate.
@@ -79,6 +80,7 @@ impl PluginGroup for RatatuiPlugins {
     fn build(self) -> PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
             .add(error::ErrorPlugin)
+            .add(kitty::KittyPlugin)
             .add(terminal::TerminalPlugin)
             .add(event::EventPlugin)
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -10,8 +10,15 @@ use std::io::{self, stdout, Stdout};
 use bevy::prelude::*;
 use color_eyre::Result;
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    cursor,
+    event::{
+        DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
+    terminal::{
+        disable_raw_mode, enable_raw_mode, supports_keyboard_enhancement, EnterAlternateScreen,
+        LeaveAlternateScreen,
+    },
     ExecutableCommand,
 };
 use ratatui::backend::CrosstermBackend;
@@ -69,11 +76,34 @@ impl RatatuiContext {
         Ok(RatatuiContext(terminal))
     }
 
+    /// Enables support for the kitty keyboard protocol.
+    /// https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+    ///
+    /// Provides additional information involving keyboard events. For example, key release events
+    /// will be reported.
+    ///
+    /// Refer to the above link for a list of terminals that support the
+    /// protocol. An `Ok` result is not a guarantee that all features are supported: you should
+    /// have fallbacks that you use until you detect the event type you are looking for.
+    pub fn enable_kitty_protocol(&mut self) -> io::Result<()> {
+        if matches!(supports_keyboard_enhancement(), Ok(true)) {
+            stdout().execute(PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::all()))?;
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Kitty keyboard protocol is not supported by this terminal.",
+            ))
+        }
+    }
+
     /// Restores the terminal, leaving the alternate screen and disabling raw mode.
     pub fn restore() -> io::Result<()> {
         stdout()
+            .execute(PopKeyboardEnhancementFlags)?
             .execute(LeaveAlternateScreen)?
-            .execute(DisableMouseCapture)?;
+            .execute(DisableMouseCapture)?
+            .execute(cursor::Show)?;
         disable_raw_mode()?;
         Ok(())
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -11,14 +11,8 @@ use bevy::prelude::*;
 use color_eyre::Result;
 use crossterm::{
     cursor,
-    event::{
-        DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags,
-        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
-    },
-    terminal::{
-        disable_raw_mode, enable_raw_mode, supports_keyboard_enhancement, EnterAlternateScreen,
-        LeaveAlternateScreen,
-    },
+    event::{DisableMouseCapture, EnableMouseCapture, PopKeyboardEnhancementFlags},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
 use ratatui::backend::CrosstermBackend;
@@ -76,31 +70,9 @@ impl RatatuiContext {
         Ok(RatatuiContext(terminal))
     }
 
-    /// Enables support for the kitty keyboard protocol.
-    /// https://sw.kovidgoyal.net/kitty/keyboard-protocol/
-    ///
-    /// Provides additional information involving keyboard events. For example, key release events
-    /// will be reported.
-    ///
-    /// Refer to the above link for a list of terminals that support the
-    /// protocol. An `Ok` result is not a guarantee that all features are supported: you should
-    /// have fallbacks that you use until you detect the event type you are looking for.
-    pub fn enable_kitty_protocol(&mut self) -> io::Result<()> {
-        if matches!(supports_keyboard_enhancement(), Ok(true)) {
-            stdout().execute(PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::all()))?;
-            Ok(())
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "Kitty keyboard protocol is not supported by this terminal.",
-            ))
-        }
-    }
-
     /// Restores the terminal, leaving the alternate screen and disabling raw mode.
     pub fn restore() -> io::Result<()> {
         stdout()
-            .execute(PopKeyboardEnhancementFlags)?
             .execute(LeaveAlternateScreen)?
             .execute(DisableMouseCapture)?
             .execute(cursor::Show)?;


### PR DESCRIPTION
## Changes
- Supplies `enable_kitty_protocol` method that uses `crossterm` helper methods to enable the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/).
- Cleans up kitty protocol flags when leaving ratatui alternate view.
- New example showing how to use the method and one example of what it supplies (keyboard "release" events).
- EDIT: Also added the `cursor::Show` during cleanup, necessary in some terminals.

## Justification
One could argue that kitty protocol support is somewhat orthogonal to what an integration between bevy and ratatui should be responsible for, but I think there are two good arguments for inclusion:
- Bevy users will be accustomed to more keyboard events than terminals supply by default, and especially if the eventual plan is to convert crossterm events into the standard bevy ones, this protocol will be required for better parity.
- If the kitty protocol flags are pushed before the ratatui alternate view is created it can cause issues with using the protocol  (or if the alternate view is exited before the flags are removed the terminal might not be left in the proper state). For this reason, handling the protocol here might cause less user frustration than pointing them elsewhere or making them add the flags themselves.

## Alternative
Alternatively, for an even more seamless setup we could just push the flags as part of the context initialization and store whether the protocol was enabled as part of the `RatatuiContext` struct. Opinion here?

## Testing
Tested with Alacritty, Kitty, iTerm, and WezTerm on macOS.