### PR TITLE
Making sure kitty setup runs after terminal setup

### DIFF
--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -7,11 +7,13 @@ use crossterm::{
     ExecutableCommand,
 };
 
+use crate::terminal;
+
 pub struct KittyPlugin;
 
 impl Plugin for KittyPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, setup);
+        app.add_systems(Startup, setup.after(terminal::setup));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! fn main() {
 //!     let wait_duration = std::time::Duration::from_secs_f64(1. / 60.); // 60 FPS
 //!     App::new()
-//!         .add_plugins(RatatuiPlugins)
+//!         .add_plugins(RatatuiPlugins::default())
 //!         .add_plugins(ScheduleRunnerPlugin::run_loop(wait_duration))
 //!         .add_systems(PreUpdate, keyboard_input_system)
 //!         .add_systems(Update, hello_world.pipe(exit_on_error))

--- a/src/ratatui.rs
+++ b/src/ratatui.rs
@@ -10,7 +10,7 @@ use crate::{error, event, kitty, mouse, terminal};
 /// use bevy::prelude::*;
 /// use bevy_ratatui::RatatuiPlugins;
 ///
-/// App::new().add_plugins(RatatuiPlugins);
+/// App::new().add_plugins(RatatuiPlugins::default());
 /// ```
 pub struct RatatuiPlugins {
     pub enable_kitty_protocol: bool,
@@ -34,7 +34,7 @@ impl Default for RatatuiPlugins {
 /// use bevy::prelude::*;
 /// use bevy_ratatui::RatatuiPlugins;
 ///
-/// App::new().add_plugins(RatatuiPlugins);
+/// App::new().add_plugins(RatatuiPlugins::default());
 /// ```
 impl PluginGroup for RatatuiPlugins {
     fn build(self) -> PluginGroupBuilder {


### PR DESCRIPTION
## Changes
- added a rule for `kitty::setup` to run after `terminal::setup`.

## Notes
It looks like moving the kitty protocol setup into its own plugin broke keyboard input- sometimes protocol setup runs before terminal setup which borks the terminal. While I believe its also possible for the cleanup functions to run out-of-order as well, I didn't notice any issues testing in a few terminals so I think we can leave it alone.

## Testing
Tested with Alacritty, iTerm, Kitty on macOS.