### PR TITLE
Removed dynamic_linking feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,7 @@ categories = ["command-line-interface"]
 keywords = ["cli", "ratatui", "terminal", "tui", "bevy"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
-    "dynamic_linking",
-] }
+bevy = { version = "0.14", default-features = false }
 bitflags = "2.6.0"
 color-eyre = "0.6.3"
 crossterm = "0.27.0"

--- a/src/input_forwarding/keyboard.rs
+++ b/src/input_forwarding/keyboard.rs
@@ -30,11 +30,11 @@ bitflags::bitflags! {
 
 /// Keyboard emulation policy
 ///
-/// - The [Automatic][EmulationPolicy::Automatic] policy will emulate key
-///   release or modifiers if they have not been detected.
+/// - The [Automatic][EmulationPolicy::Automatic] policy will emulate key release or modifiers if
+///   they have not been detected.
 ///
-/// - The [Manual][EmulationPolicy::Manual] policy defines whether modifiers or
-///   key releases will be emulated.
+/// - The [Manual][EmulationPolicy::Manual] policy defines whether modifiers or key releases will be
+///   emulated.
 ///
 /// Note: If key releases are emulated and key releases are provided by the
 /// terminal, dupliate events may be sent.

--- a/src/input_forwarding/mod.rs
+++ b/src/input_forwarding/mod.rs
@@ -5,7 +5,8 @@
 //!
 //! - `ButtonInput`[`<Key>`][bevy::input::keyboard::Key] for logical keys,
 //! - `ButtonInput`[`<KeyCode>`][bevy::input::keyboard::KeyCode] for physical keys,
-//! - and `EventReader<`[`KeyboardInput`][bevy::input::keyboard::KeyboardInput]`>` for its lowest-level events.
+//! - and `EventReader<`[`KeyboardInput`][bevy::input::keyboard::KeyboardInput]`>` for its
+//!   lowest-level events.
 //!
 //! The crossterm events are still present and usable with this plugin present.
 //!


### PR DESCRIPTION
Removing dynamic linking from bevy dependency in order to prevent it from opting-in downstream packages pulling in this dependency.

Bevy dynamic linking is a bit rickety (has [some](https://github.com/bevyengine/bevy/issues/14117) [open](https://github.com/bevyengine/bevy/issues/14129) [issues](https://github.com/bevyengine/bevy/issues/6723)) and so I think its best to leave off for now, as the issues will come up if _any dependency_ pulls in `dynamic_linking`/`bevy_dylib`. Ran into this problem in one of my own projects.

Tested the examples and doc tests.