### PR TITLE
version 0.7.0 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ checksum = "2af9e30b40fb3f0a80a658419f670f2de1e743efcaca1952c43cdcc923287944"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "bevy",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshka/bevy_ratatui"


### PR DESCRIPTION
Bumping the version number to preserve the bevy@0.14 => bevy_ratatui@0.6 mapping.

IIRC release-plz will tag and execute the release when the version number is manually changed like this.