### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
-## [0.9.4](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.3...v0.9.4) - 2025-11-12
+## [0.10.0](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.3...v0.10.0) - 2025-11-12
 
 ### Other
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ checksum = "28ab4074e7b781bab84e9b0a41ede245d673d1f75646ce0db27643aedcfb3a85"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "bevy",
  "bitflags 2.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.9.4"
+version = "0.10.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ There are also a handful of features relating to running Bevy in `no_std` mode.
 
 | bevy  | bevy_ratatui |
 |-------|--------------|
+| 0.17  | 0.10         |
 | 0.16  | 0.9          |
 | 0.15  | 0.7          |
 | 0.14  | 0.6          |


### PR DESCRIPTION


## 🤖 New release

* `bevy_ratatui`: 0.9.3 -> 0.10.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.4](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.3...v0.10.0) - 2025-11-12

### Other

- migration to bevy 0.17
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).