### PR TITLE
fixed missing backquote / backtick / tilde forwarding

### DIFF
--- a/src/crossterm_context/translation/keyboard_translation.rs
+++ b/src/crossterm_context/translation/keyboard_translation.rs
@@ -649,6 +649,11 @@ fn to_bevy_keycode(
                 mods |= m::SHIFT;
                 Some(b::Slash)
             }
+            '`' => Some(b::Backquote),
+            '~' => {
+                mods |= m::SHIFT;
+                Some(b::Backquote)
+            }
             ' ' => Some(b::Space),
             '1' => Some(b::Digit1),
             '2' => Some(b::Digit2),


### PR DESCRIPTION
this was a quick hack for my needs, but I'm wondering if there could be a less fragile way of handling this. Haven't looked into it yet but will chime in with better ideas if I get to it! First thought is to just forward the character somehow? Unsure how relevant it is if the whole keyboard has been matched, but a guess is this might also prevent pasting strings with weird characters in it.