### PR TITLE
Remove default crossterm dependency to enable web builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4515,7 +4515,6 @@ dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
- "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
 ]
@@ -4550,16 +4549,6 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
-]
-
-[[package]]
-name = "ratatui-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
-dependencies = [
- "ratatui-core",
- "ratatui-widgets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,11 @@ tracing = "0.1.44"
 [dev-dependencies]
 rand = "0.9.2"
 bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
-ratatui = { version = "0.30.0", features = ["unstable-widget-ref"] }
+ratatui = { version = "0.30.0", default-features = false, features = [
+    "underline-color",
+    "layout-cache",
+    "unstable-widget-ref",
+] }
 
 # Enable a small amount of optimization in debug mode
 [profile.dev]


### PR DESCRIPTION
I tried building `bevy_ratatui` for web ahead of the [Bevy Jam 7](https://itch.io/jam/bevy-jam-7) and got it working after only a minor snag.

`ratatui` depends on `crossterm` by default and the default features aren't currently disabled here so crossterm was being pulled in regardless of whether `bevy_ratatui`'s crossterm feature was enabled.

Simple fix, tested with the demos using the [Bevy CLI](https://github.com/TheBevyFlock/bevy_cli):
`bevy run --example demo --no-default-features -F windowed,async_executor,keyboard,mouse web`
* note this produces an error without further configuration for `getrandom` - see [here](https://thebevyflock.github.io/bevy_cli/cli/web/getrandom.html) for details. I just added the config locally for the sake of testing, dunno if there's any appropriate `Cargo.toml` update for a library to make it work for examples