### PR TITLE
chore: release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.11.2](https://github.com/ratatui/bevy_ratatui/compare/v0.11.1...v0.11.2) - 2026-07-17
+
+### Other
+
+- Add snake example
+- Fix terminal input schedule ordering
+- Small typo
+- Delay modifier release by at least 1 tick
+- Bump rand from 0.9.2 to 0.9.3 ([#94](https://github.com/ratatui/bevy_ratatui/pull/94))
+
 ## [0.11.1](https://github.com/ratatui/bevy_ratatui/compare/v0.11.0...v0.11.1) - 2026-02-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ checksum = "4f98cbc6d34bbdb58240b72ed1731931b4991a893b3a3238bb7c42ae054aa676"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bevy",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ratatui/bevy_ratatui"


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui`: 0.11.1 -> 0.11.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.2](https://github.com/ratatui/bevy_ratatui/compare/v0.11.1...v0.11.2) - 2026-07-17

### Other

- Add snake example
- Fix terminal input schedule ordering
- Small typo
- Delay modifier release by at least 1 tick
- Bump rand from 0.9.2 to 0.9.3 ([#94](https://github.com/ratatui/bevy_ratatui/pull/94))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).