### PR TITLE
fix incorrect caching in workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,8 +26,6 @@ jobs:
           components: rustfmt
       - name: cargo fmt
         run: cargo fmt -- --check
-      - name: cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
 
   clippy:
     name: clippy - ${{ matrix.toolchain }}
@@ -49,10 +47,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: clippy
-        uses: clechasseur/rs-clippy-check@v3
       - name: cache cargo dependencies
         uses: Swatinem/rust-cache@v2
+      - name: clippy
+        uses: clechasseur/rs-clippy-check@v3
 
   doc:
     name: doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,8 @@ jobs:
       - name: cargo generate-lockfile
         run: cargo generate-lockfile
 
-      - name: cargo test
-        run: cargo test --locked --all-features --all-targets
-
       - name: cache cargo dependencies
         uses: Swatinem/rust-cache@v2
+
+      - name: cargo test
+        run: cargo test --locked --all-features --all-targets


### PR DESCRIPTION
It might sound confusing, but you must run the cache action BEFORE the
step that benefits from the cache. Where you invoke the cache action is
where you hope to RESTORE from cache. The actual caching is done in an
automatic post-step to the job.

As it is now, the caching has no effect.

I also removed caching where it is unneccesary. Formatting doesn't need
us to build the code, so no caching needed.
