### PR TITLE
Add system set for managing context during startup

### DIFF
--- a/src/crossterm_context/kitty.rs
+++ b/src/crossterm_context/kitty.rs
@@ -8,7 +8,7 @@ use ratatui::crossterm::{
     terminal::supports_keyboard_enhancement,
 };
 
-use crate::ratatui_plugin::context_setup;
+use crate::ContextSystems;
 
 /// Plugin responsible for enabling the Kitty keyboard protocol in the current buffer.
 ///
@@ -24,7 +24,7 @@ pub struct KittyPlugin;
 
 impl Plugin for KittyPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        app.add_systems(Startup, kitty_setup.after(context_setup));
+        app.add_systems(Startup, kitty_setup.in_set(ContextSystems::PostSetup));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ mod ratatui_plugin;
 mod windowed_context;
 
 pub use ratatui_context::RatatuiContext;
-pub use ratatui_plugin::RatatuiPlugins;
+pub use ratatui_plugin::{ContextSystems, RatatuiPlugins};
 
 #[cfg(feature = "crossterm")]
 pub use ratatui::crossterm;

--- a/src/ratatui_plugin.rs
+++ b/src/ratatui_plugin.rs
@@ -1,5 +1,6 @@
 use bevy::{
     app::{Plugin, PluginGroup, PluginGroupBuilder, Startup},
+    ecs::schedule::{IntoScheduleConfigs, SystemSet},
     prelude::{Commands, Result},
 };
 
@@ -53,8 +54,28 @@ pub struct ContextPlugin;
 
 impl Plugin for ContextPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        app.add_systems(Startup, context_setup);
+        app.configure_sets(
+            Startup,
+            (
+                ContextSystems::PreSetup,
+                ContextSystems::Setup,
+                ContextSystems::PostSetup,
+            )
+                .chain(),
+        )
+        .add_systems(Startup, context_setup.in_set(ContextSystems::Setup));
     }
+}
+
+/// System sets for managing the lifecycle of `RatatuiContext`
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ContextSystems {
+    /// Runs before `RatatuiContext` is added
+    PreSetup,
+    /// Adds the `RatatuiContext` to the ECS world
+    Setup,
+    /// Runs after `RatatuiContext` is added
+    PostSetup,
 }
 
 /// A startup system that sets up the terminal context.


### PR DESCRIPTION
Add a system set so that the user can run systems before or after `RatatuiContext` is added during `Startup`.

This avoids having to expose the actual `context_setup` system to the public API.