### PR TITLE
Delay modifier release by at least 1 tick

### DIFF
--- a/src/crossterm_context/translation/keyboard_translation.rs
+++ b/src/crossterm_context/translation/keyboard_translation.rs
@@ -300,6 +300,7 @@ fn send_key_messages_with_emulation(
     mut keys: MessageReader<KeyMessage>,
     bevy_window: Single<Entity, With<DummyWindow>>,
     mut modifiers: Local<Modifiers>,
+    mut delayed_modifiers: Local<Modifiers>,
     mut last_pressed: Local<LastPress>,
     mut keyboard_input: MessageWriter<KeyboardInput>,
     release_key: Res<ReleaseKey>,
@@ -374,6 +375,11 @@ fn send_key_messages_with_emulation(
             .emulate_capabilities(&detected)
             .contains(Capability::MODIFIER)
     {
+        // Delay modifier release until the next tick, if they were pressed under the current tick
+        if let ReleaseKey::Immediate | ReleaseKey::FrameCount(0 | 1) = &*release_key {
+            std::mem::swap(&mut *modifiers, &mut *delayed_modifiers);
+        };
+
         // Release the modifiers too if we've timed out.
         for flag in **modifiers {
             let state = ButtonState::Released;


### PR DESCRIPTION
Currently, when using key release emulation with `Immediate`, `FrameCount(0)` or `FrameCount(1)`, modifiers will be released immediately in the same tick as they were pressed.

This produces an incorrect stream of input events:

```rust
ButtonInput { pressed: {}, just_pressed: {}, just_released: {} }
ButtonInput { pressed: {KeyA}, just_pressed: {KeyA, ControlLeft}, just_released: {ControlLeft} }
ButtonInput { pressed: {}, just_pressed: {}, just_released: {KeyA} }
```

Notice how `ControlLeft` is present in both `just_pressed` and `just_released` on the same tick.

This PR introduces a conditional delay so that modifiers are never released on the same tick as they were pressed.

With the changes in this PR, the produced input stream is now correct:

```rust
ButtonInput { pressed: {}, just_pressed: {}, just_released: {} }
ButtonInput { pressed: {KeyA, ControlLeft}, just_pressed: {KeyA, ControlLeft}, just_released: {}
ButtonInput { pressed: {}, just_pressed: {}, just_released: {KeyA, ControlLeft} }
```

Note that the delay is only introduced under certain emulation modes that induces same-tick mod releases, other modes will not be affected.