### PR TITLE
Add snake terminal example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ ratatui = { version = "0.30.0", default-features = false, features = [
     "unstable-widget-ref",
 ] }
 
+[[example]]
+name = "snake"
+path = "examples/snake/main.rs"
+test = true
+
 # Enable a small amount of optimization in debug mode
 [profile.dev]
 opt-level = 1

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ fn draw_system(mut context: ResMut<RatatuiContext>) -> Result {
 
 To read user input, you can listen for the crossterm input messages forwarded by
 this crate:
+
 ```rust
 use bevy::app::AppExit;
 use bevy_ratatui::event::KeyMessage;
@@ -55,6 +56,7 @@ fn input_system(mut messages: MessageReader<KeyMessage>, mut exit: MessageWriter
     }
 }
 ```
+
 ...or use the `enable_input_forwarding` option in `RatatuiPlugins` which will
 map crossterm input events to normal bevy input messages.
 
@@ -63,6 +65,8 @@ map crossterm input events to normal bevy input messages.
 ![Made with VHS](https://vhs.charm.sh/vhs-2g0S6RgGGQHseTCNItEQhg.gif)
 
 See the [demo example](examples/demo.rs) for the code and more information.
+For a larger multi-file game example, see the
+[snake example](examples/snake/README.md).
 
 ## features
 
@@ -76,12 +80,14 @@ There are also a handful of features relating to running Bevy in `no_std` mode.
 ## see also
 
 ### integrates with
+
 - [bevy](https://github.com/bevyengine/bevy): A refreshingly simple data-driven
   game engine built in Rust.
 - [ratatui](https://github.com/ratatui/ratatui): A Rust crate for cooking up
   terminal user interfaces (TUIs).
 
 ### more tools
+
 - [egui_ratatui](https://github.com/gold-silver-copper/egui_ratatui): A ratatui
   backend that is also an egui widget. Deploy on web with WASM or ship natively
   with bevy, macroquad, or eframe. Demo at
@@ -91,6 +97,7 @@ There are also a handful of features relating to running Bevy in `no_std` mode.
   camera's rendered image to text and draws it to the terminal with ratatui.
 
 ### alternatives
+
 - [widgetui](https://github.com/TheEmeraldBee/widgetui): A wrapper for ratatui
   that reduces boilerplate and handles the update loop. Uses an approach
   similar to bevy systems.

--- a/examples/snake/README.md
+++ b/examples/snake/README.md
@@ -1,0 +1,132 @@
+# Snake example
+
+This example shows a complete terminal game built with `bevy_ratatui`. It is intentionally larger
+than the small examples in this repository so the full `bevy_ratatui` application flow remains
+visible: terminal events enter as Bevy messages, systems update resources in an explicit order, and
+a final system projects those resources into a Ratatui frame.
+
+Run it with:
+
+```sh
+cargo run --example snake
+```
+
+## `bevy_ratatui` application pattern
+
+The reusable part of this example is the path through the Bevy schedules:
+
+1. `RatatuiPlugins` initializes the terminal context and emits terminal events such as `KeyMessage`.
+2. A `PreUpdate` system translates those terminal-specific messages into the application's own
+   `GameCommand` messages.
+3. Chained `Update` systems synchronize terminal-dependent resources, read commands, and advance
+   application state in a deliberate order.
+4. A `PostUpdate` system borrows `RatatuiContext` and calls `draw`, so rendering sees the state
+   produced by the current update without owning or mutating the game rules.
+
+This input-resource-render flow applies to dashboards, editors, and other terminal applications as
+well as games. The turn queue, crash grace, and partial-block animation are Snake policies rather
+than requirements imposed by `bevy_ratatui`.
+
+## Module map
+
+The first reading path follows the reusable `bevy_ratatui` integration:
+
+- [`main.rs`](main.rs) wires the Bevy app and acts as the Rustdoc table of contents.
+- [`controls.rs`](controls.rs) translates `KeyMessage` values into `GameCommand` messages. This
+  keeps terminal key codes out of the game rules.
+- [`game_loop.rs`](game_loop.rs) owns the Bevy runtime glue and `GameTiming`: applying commands,
+  advancing logical movement, and managing the wall-clock collision grace period.
+- [`terminal.rs`](terminal.rs) lays out and renders the current game state with Ratatui.
+
+The game-rule modules can be read without following terminal rendering details:
+
+- [`game.rs`](game.rs) owns state transitions for movement, scoring, collision, restart, and resize.
+- [`snake.rs`](snake.rs) owns logical segments, the latest movement snapshot, direction, and queued
+  turns.
+- [`geometry.rs`](geometry.rs) owns board coordinates and movement directions shared by the rules,
+  controls, and renderer.
+
+The remaining modules support terminal sizing and the optional smooth-rendering details:
+
+- [`playfield.rs`](playfield.rs) derives the logical board and availability state from the terminal
+  size so update and rendering follow the same environmental policy.
+- [`hud.rs`](hud.rs) renders score, controls, overlays, and the small-terminal fallback.
+- [`terminal_cells.rs`](terminal_cells.rs) owns the wide-cell projection and the foreground,
+  background, and Unicode glyph rules for individual terminal cells.
+- [`snake_rendering.rs`](snake_rendering.rs) renders stable body cells and smoothly interpolated
+  head and tail cells, including fractional coverage calculations.
+
+The later modules are not prerequisites for understanding how `RatatuiPlugins`, messages,
+resources, schedules, and `RatatuiContext::draw` fit together.
+
+## Design notes
+
+The logical board fills the terminal area left after the HUD and controls. A terminal cell is
+usually taller than it is wide, so the renderer draws each logical board cell as two side-by-side
+terminal cells. This makes vertical and horizontal movement feel closer in physical distance
+without making the arena so dense that play becomes empty and hard to read.
+
+The rules still move on whole board cells, but rendering draws the head and tail between the
+previous and current cell positions using Unicode eighth-block glyphs. The middle body stays on the
+stable logical path. That split keeps motion responsive without making turns flicker as neighboring
+body segments round through a corner at different times. The moving head leaves body-colored
+underlay in the old head cell. The moving tail reveals board background in the old tail cell while
+leaving body-colored underlay in the current tail cell so it stays connected to the rest of the
+snake. Collision, food placement, and scoring never depend on fractional coordinates. The fruit
+uses a double-width emoji in the same two-column cell shape as the snake.
+
+The example restarts the current round after a terminal resize changes the playable board. Snake
+segments and food are stored as board coordinates, so resizing in place would need a policy for
+scaling or clipping an active snake. Restarting keeps the example predictable and preserves the
+high score for the session. If the terminal becomes too small to fit the minimum board, the game
+loop suspends without changing the player's pause state. Returning to the same valid dimensions
+continues the current round instead of allowing the snake to move invisibly behind the size warning.
+
+The controls use a small turn queue instead of a single pending direction. If the snake is moving
+right and the player presses `Up, Left` before the next movement tick, the game applies `Up` on the
+next tick and `Left` on the tick after that. Reversal checks compare a new input to the last queued
+direction, so `Right, Up, Left` is valid but `Right, Up, Down` is not.
+Direction keys accept terminal key-repeat events, but pause and restart only accept the initial
+press. Repeating a movement direction is harmless and responsive; repeating a toggle or reset would
+make one physical key hold produce several state changes.
+
+The game also gives the player a short crash-grace window. Taneli Armanto
+[described the original idea][history-of-snake] as a tiny delay that made fast edge turns less
+frustrating. In [another interview][oral-history], he described that delay as a few extra
+milliseconds right before a crash where the player could still turn and continue. That same
+interview describes Snake speed as the delay between position steps, not as a fixed 60 FPS render
+loop. This example models the crash delay as a short wall-clock timer in `game_loop.rs`, separate
+from both the render frame and the normal movement tick. A late turn must actually move to safety;
+turning into another collision ends the round instead of granting another grace window.
+
+The repeating movement timer reports how many logical intervals elapsed during each render frame.
+The loop processes up to four of those steps, preserving normal game speed through short scheduler
+stalls while preventing a debugger pause or suspended terminal from producing an unbounded burst of
+moves. Pause and terminal-size suspension do not reset the timer, so the partial head and tail stay
+at their current visual positions until play resumes. Collision completes the previous interpolation
+before showing crash grace, avoiding a one-cell visual rewind when a failed step does not update the
+snake path.
+
+`game_loop.rs` contains Bevy systems, but only the systems that drive the game loop; input
+translation and rendering stay near their own concepts. Module docs explain ownership and the
+overall model. Item docs keep policy, invariants, and edge-case rationale close to the constants,
+resources, fields, and helpers that implement those decisions so readers can distinguish reusable
+Bevy patterns from choices made specifically for Snake.
+
+## Validation
+
+The example has unit tests for the framework-independent rules, key-repeat policy, timing
+boundaries, terminal-size suspension, interpolation underlays, and terminal-size policy:
+
+```sh
+cargo test --example snake
+```
+
+The example also participates in workspace target checks:
+
+```sh
+cargo check --workspace --all-targets
+```
+
+[history-of-snake]: https://www.itsnicethat.com/features/taneli-armanto-the-history-of-snake-design-legacies-230221
+[oral-history]: https://melmagazine.com/en-us/story/snake-nokia-6110-oral-history-taneli-armanto

--- a/examples/snake/controls.rs
+++ b/examples/snake/controls.rs
@@ -1,0 +1,139 @@
+//! Terminal controls for the snake example.
+//!
+//! [`bevy_ratatui::RatatuiPlugins`] publishes terminal input as messages such as [`KeyMessage`]. A
+//! useful application boundary is to translate those transport-specific events once into a small
+//! application message such as [`GameCommand`]. Downstream systems can then express intent without
+//! depending on Crossterm key codes, and another input source can emit the same commands later.
+//!
+//! The repeat policy remains application-specific. Snake accepts repeats for directions so held
+//! keys stay responsive, but accepts pause and restart only on the initial press because repeating
+//! those commands would produce several state changes for one physical key hold.
+
+use bevy::prelude::*;
+use bevy_ratatui::event::KeyMessage;
+use ratatui::crossterm::event::{KeyCode, KeyEventKind};
+
+use crate::geometry::Direction;
+
+/// Player intent after terminal-specific input has been translated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Message)]
+pub enum GameCommand {
+    /// Queue a turn for the next snake step.
+    Turn(Direction),
+    /// Pause or resume the current round.
+    TogglePause,
+    /// Start a fresh round on the current board.
+    Restart,
+    /// Exit the example.
+    Quit,
+}
+
+/// Translates `bevy_ratatui` key messages into application-level commands.
+///
+/// `MessageReader` and `MessageWriter` keep this system independent from the
+/// [`Game`](crate::game::Game) resource. That separation is useful when input mapping and
+/// application behavior need different tests or schedule placement.
+pub fn translate_keyboard_input(
+    mut key_messages: MessageReader<KeyMessage>,
+    mut game_commands: MessageWriter<GameCommand>,
+) {
+    for message in key_messages.read() {
+        if let Some(command) = command_for_key(message.code, message.kind) {
+            game_commands.write(command);
+        }
+    }
+}
+
+/// Maps one terminal key event to player intent.
+///
+/// Movement is the only repeatable intent. One-shot commands reject both repeat and release events
+/// so terminal repeat settings cannot make pause state or round initialization nondeterministic.
+fn command_for_key(code: KeyCode, kind: KeyEventKind) -> Option<GameCommand> {
+    if kind == KeyEventKind::Release {
+        return None;
+    }
+
+    let command = match code {
+        KeyCode::Up => GameCommand::Turn(Direction::Up),
+        KeyCode::Down => GameCommand::Turn(Direction::Down),
+        KeyCode::Left => GameCommand::Turn(Direction::Left),
+        KeyCode::Right => GameCommand::Turn(Direction::Right),
+        KeyCode::Esc => GameCommand::Quit,
+        KeyCode::Char(' ') => GameCommand::TogglePause,
+        KeyCode::Char(character) => match character.to_ascii_lowercase() {
+            'w' => GameCommand::Turn(Direction::Up),
+            's' => GameCommand::Turn(Direction::Down),
+            'a' => GameCommand::Turn(Direction::Left),
+            'd' => GameCommand::Turn(Direction::Right),
+            'p' => GameCommand::TogglePause,
+            'r' => GameCommand::Restart,
+            'q' => GameCommand::Quit,
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    if kind == KeyEventKind::Repeat && !matches!(command, GameCommand::Turn(_)) {
+        return None;
+    }
+
+    Some(command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_movement_keys_to_turns() {
+        assert_eq!(
+            command_for_key(KeyCode::Up, KeyEventKind::Press),
+            Some(GameCommand::Turn(Direction::Up))
+        );
+        assert_eq!(
+            command_for_key(KeyCode::Char('a'), KeyEventKind::Press),
+            Some(GameCommand::Turn(Direction::Left))
+        );
+        assert_eq!(
+            command_for_key(KeyCode::Char('D'), KeyEventKind::Press),
+            Some(GameCommand::Turn(Direction::Right))
+        );
+    }
+
+    #[test]
+    fn maps_control_keys_to_commands() {
+        assert_eq!(
+            command_for_key(KeyCode::Char('p'), KeyEventKind::Press),
+            Some(GameCommand::TogglePause)
+        );
+        assert_eq!(
+            command_for_key(KeyCode::Char(' '), KeyEventKind::Press),
+            Some(GameCommand::TogglePause)
+        );
+        assert_eq!(
+            command_for_key(KeyCode::Char('r'), KeyEventKind::Press),
+            Some(GameCommand::Restart)
+        );
+        assert_eq!(
+            command_for_key(KeyCode::Esc, KeyEventKind::Press),
+            Some(GameCommand::Quit)
+        );
+    }
+
+    #[test]
+    fn repeats_only_repeat_movement_intent() {
+        assert_eq!(
+            command_for_key(KeyCode::Up, KeyEventKind::Repeat),
+            Some(GameCommand::Turn(Direction::Up))
+        );
+        assert_eq!(
+            command_for_key(KeyCode::Char('p'), KeyEventKind::Repeat),
+            None
+        );
+        assert_eq!(
+            command_for_key(KeyCode::Char('r'), KeyEventKind::Repeat),
+            None
+        );
+        assert_eq!(command_for_key(KeyCode::Up, KeyEventKind::Release), None);
+    }
+}

--- a/examples/snake/game.rs
+++ b/examples/snake/game.rs
@@ -1,0 +1,592 @@
+//! Framework-independent snake rules and state.
+//!
+//! This module deliberately avoids terminal and Bevy system concerns. The rest of the example can
+//! resize the board, send commands, and render frames, but this module owns the rules that decide
+//! whether the snake moved, ate food, collided, paused, or restarted.
+//!
+//! A collision is reported to [`crate::game_loop`], which owns the real-time correction window.
+//! Keeping that timer out of this module lets rule tests advance one logical cell at a time without
+//! constructing a Bevy app or Ratatui buffer.
+
+use std::time::Duration;
+
+#[cfg(test)]
+use std::collections::VecDeque;
+
+use rand::Rng;
+
+use bevy::prelude::*;
+
+use crate::{
+    geometry::{Board, Direction, Point},
+    snake::Snake,
+};
+
+/// Fallback board width before the first terminal-size sync.
+pub const DEFAULT_BOARD_WIDTH: i16 = 48;
+/// Fallback board height before the first terminal-size sync.
+pub const DEFAULT_BOARD_HEIGHT: i16 = 48;
+/// Initial delay between logical movement steps.
+pub const BASE_STEP_DURATION: Duration = Duration::from_millis(140);
+/// Per-level reduction in delay between movement steps.
+const LEVEL_STEP_REDUCTION: Duration = Duration::from_millis(15);
+/// Fastest movement cadence, preventing high levels from becoming unrenderable.
+const MIN_STEP_DURATION: Duration = Duration::from_millis(60);
+/// Base score awarded for food before applying the current level multiplier.
+const POINTS_PER_FOOD: u32 = 10;
+/// Score interval at which movement advances to the next level.
+const POINTS_PER_LEVEL: u32 = 50;
+
+/// Current round state.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum GameStatus {
+    /// The movement timer can advance the snake.
+    Playing,
+
+    /// The round is suspended until the player resumes.
+    Paused,
+
+    /// The round ended through wall or self collision.
+    GameOver,
+}
+
+/// Result of one whole-cell movement attempt.
+///
+/// The Bevy loop uses this result to apply real-time policy without exposing timers to the
+/// framework-independent rule model. In particular, [`Self::Collision`] lets the runtime decide
+/// whether to offer a short correction window before ending the round.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StepOutcome {
+    /// The snake moved without eating.
+    Moved,
+
+    /// The snake ate food, grew, and scored.
+    AteFood,
+
+    /// The proposed head position intersects a wall or surviving body segment.
+    Collision,
+
+    /// The game was paused or already over.
+    Noop,
+}
+
+/// Complete mutable state for one snake session.
+///
+/// The high score is session state and survives restarts. The score, snake, food, and status belong
+/// to the current round. Keeping both in one Bevy resource makes the example easy to inspect while
+/// still keeping rule updates local to this type. `bevy_ratatui` does not require one state
+/// resource; this example uses one because input, timing, and rendering systems all need a shared
+/// model and these methods keep Bevy scheduling out of the rules.
+#[derive(Debug, Resource)]
+pub struct Game {
+    /// Logical bounds used by movement, collision, and food placement.
+    board: Board,
+
+    /// Logical snake geometry, latest movement snapshot, and accepted future turns.
+    snake: Snake,
+
+    /// Unoccupied board cell containing food, or `None` after filling the board.
+    food: Option<Point>,
+
+    /// Score accumulated during the current round.
+    score: u32,
+
+    /// Highest score reached by any round in this process.
+    high_score: u32,
+
+    /// Lifecycle state controlling whether logical movement can advance.
+    status: GameStatus,
+}
+
+impl Default for Game {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Game {
+    /// Creates a game using the fallback board size.
+    pub fn new() -> Self {
+        Self::new_with_board_and_high_score(
+            Board::new(DEFAULT_BOARD_WIDTH, DEFAULT_BOARD_HEIGHT),
+            0,
+        )
+    }
+
+    /// Creates a fresh round while carrying process-level score state across restarts.
+    fn new_with_board_and_high_score(board: Board, high_score: u32) -> Self {
+        let mut game = Self {
+            board,
+            snake: Snake::new(board),
+            food: None,
+            score: 0,
+            high_score,
+            status: GameStatus::Playing,
+        };
+        game.spawn_food();
+        game
+    }
+
+    /// Starts a new round on the current board and keeps the session high score.
+    pub fn restart(&mut self) {
+        self.restart_on_board(self.board);
+    }
+
+    /// Starts a new round when the terminal-sized board changes.
+    ///
+    /// The example chooses restart-on-resize instead of scaling active coordinates. That keeps the
+    /// game rules simple enough to study and avoids surprising partial snakes after a resize.
+    ///
+    /// Boards too narrow for [`Snake::new`] are ignored, as are unchanged boards. Returns whether
+    /// the current round was restarted on a different board.
+    pub fn resize_board(&mut self, board: Board) -> bool {
+        if self.board != board && Snake::can_start_on(board) {
+            self.restart_on_board(board);
+            return true;
+        }
+
+        false
+    }
+
+    /// Replaces all round state while preserving the session high score.
+    fn restart_on_board(&mut self, board: Board) {
+        let high_score = self.high_score;
+        *self = Self::new_with_board_and_high_score(board, high_score);
+    }
+
+    /// Toggles a live round between playing and paused.
+    ///
+    /// Game-over is intentionally stable: only an explicit restart creates another round.
+    pub fn toggle_pause(&mut self) {
+        self.status = match self.status {
+            GameStatus::Playing => GameStatus::Paused,
+            GameStatus::Paused => GameStatus::Playing,
+            GameStatus::GameOver => GameStatus::GameOver,
+        };
+    }
+
+    /// Queues a direction for the next movement step.
+    ///
+    /// The queue prevents dropped quick turns, while the reversal checks prevent the snake from
+    /// turning directly into itself between ticks. Reversal is checked against the last queued turn
+    /// when one exists, so `Right -> Up -> Left` is accepted but `Right -> Up -> Down` is rejected.
+    pub fn queue_turn(&mut self, direction: Direction) -> bool {
+        if self.status != GameStatus::Playing {
+            return false;
+        }
+
+        self.snake.queue_turn(direction)
+    }
+
+    /// Advances the snake by one logical step.
+    ///
+    /// This method is the framework-independent rule boundary used by the Bevy game loop. It
+    /// updates the current round and returns a small outcome that tests can assert without
+    /// inspecting rendering state.
+    pub fn step(&mut self) -> StepOutcome {
+        if self.status != GameStatus::Playing {
+            return StepOutcome::Noop;
+        }
+
+        self.snake.apply_next_turn();
+        let next_head = self.snake.next_head();
+
+        let ate_food = self.food == Some(next_head);
+        if !self.board.contains(next_head) || self.snake.would_collide(next_head, ate_food) {
+            return StepOutcome::Collision;
+        }
+
+        self.snake.advance(next_head, ate_food);
+        if ate_food {
+            self.score += POINTS_PER_FOOD * self.level();
+            self.high_score = self.high_score.max(self.score);
+            self.spawn_food();
+            StepOutcome::AteFood
+        } else {
+            StepOutcome::Moved
+        }
+    }
+
+    /// Returns the current movement cadence.
+    ///
+    /// Higher levels shorten the timer duration down to a fixed floor.
+    pub fn step_duration(&self) -> Duration {
+        let reduction = LEVEL_STEP_REDUCTION * self.level().saturating_sub(1);
+        BASE_STEP_DURATION
+            .saturating_sub(reduction)
+            .max(MIN_STEP_DURATION)
+    }
+
+    /// Returns the one-based speed and scoring multiplier derived from the current score.
+    pub fn level(&self) -> u32 {
+        self.score / POINTS_PER_LEVEL + 1
+    }
+
+    /// Returns whether the game is currently accepting movement steps.
+    pub fn is_playing(&self) -> bool {
+        self.status == GameStatus::Playing
+    }
+
+    /// Returns the logical board used by the current round.
+    pub fn board(&self) -> Board {
+        self.board
+    }
+
+    /// Returns the logical snake and its latest movement snapshot.
+    pub fn snake(&self) -> &Snake {
+        &self.snake
+    }
+
+    /// Returns the current food cell, or `None` after filling the board.
+    pub fn food(&self) -> Option<Point> {
+        self.food
+    }
+
+    /// Returns the score accumulated during the current round.
+    pub fn score(&self) -> u32 {
+        self.score
+    }
+
+    /// Returns the highest score reached during this process.
+    pub fn high_score(&self) -> u32 {
+        self.high_score
+    }
+
+    /// Returns the current round lifecycle state.
+    pub fn status(&self) -> GameStatus {
+        self.status
+    }
+
+    /// Places food with process randomness after construction or growth.
+    fn spawn_food(&mut self) {
+        let mut rng = rand::rng();
+        self.spawn_food_with_rng(&mut rng);
+    }
+
+    /// Places food using an injected random source so placement policy remains testable.
+    fn spawn_food_with_rng(&mut self, rng: &mut impl Rng) {
+        let free_cells = self.free_cells();
+        if free_cells.is_empty() {
+            self.food = None;
+            self.end_game();
+            return;
+        }
+
+        let index = rng.random_range(0..free_cells.len());
+        self.food = Some(free_cells[index]);
+    }
+
+    /// Collects legal food positions in stable board order before random selection.
+    ///
+    /// Allocating here is acceptable for this example because food placement is infrequent and the
+    /// explicit list makes the occupied-cell rule easier to inspect than rejection sampling.
+    fn free_cells(&self) -> Vec<Point> {
+        let mut cells = Vec::new();
+        for y in 0..self.board.height() {
+            for x in 0..self.board.width() {
+                let point = Point { x, y };
+                if !self.snake.contains(point) {
+                    cells.push(point);
+                }
+            }
+        }
+        cells
+    }
+
+    /// Ends the current round and commits its score to session state.
+    fn end_game(&mut self) {
+        self.status = GameStatus::GameOver;
+        self.high_score = self.high_score.max(self.score);
+    }
+
+    /// Ends the current round after the runtime rejects or expires a collision correction.
+    pub fn end_after_collision(&mut self) {
+        self.end_game();
+    }
+}
+
+#[cfg(test)]
+impl Game {
+    /// Places deterministic food without invoking the random production policy.
+    pub fn place_food_for_test(&mut self, point: Point) {
+        self.food = Some(point);
+    }
+
+    /// Replaces snake geometry while preserving the invariants expected by movement and rendering.
+    pub fn replace_snake_for_test(&mut self, snake: VecDeque<Point>, direction: Direction) {
+        self.snake.replace_segments_for_test(snake, direction);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::*;
+    use crate::{
+        geometry::{Board, Direction, Point},
+        snake::STARTING_LENGTH,
+    };
+
+    /// Establishes score-dependent test scenarios without weakening production visibility.
+    fn set_score(game: &mut Game, score: u32) {
+        game.score = score;
+        game.high_score = game.high_score.max(score);
+    }
+
+    #[test]
+    fn initial_board_and_snake_are_valid() {
+        let game = Game::new();
+
+        assert_eq!(game.status(), GameStatus::Playing);
+        assert_eq!(game.snake().segment_count(), STARTING_LENGTH);
+        assert!(
+            game.snake()
+                .segments()
+                .iter()
+                .all(|point| game.board().contains(*point))
+        );
+        assert!(game.food().is_some_and(|food| !game.snake().contains(food)));
+    }
+
+    #[test]
+    fn food_placement_avoids_the_snake() {
+        let game = Game::new();
+
+        assert!(game.food().is_some_and(|food| !game.snake().contains(food)));
+    }
+
+    #[test]
+    fn movement_advances_the_head_and_preserves_length() {
+        let mut game = Game::new();
+        let original_head = game.snake().head();
+        let original_len = game.snake().segment_count();
+        game.place_food_for_test(Point::new(0, 0));
+
+        assert_eq!(game.step(), StepOutcome::Moved);
+
+        assert_eq!(game.snake().head(), original_head.offset(Direction::Right));
+        assert_eq!(game.snake().segment_count(), original_len);
+    }
+
+    #[test]
+    fn eating_food_grows_the_snake_and_scores() {
+        let mut game = Game::new();
+        let original_len = game.snake().segment_count();
+        let food = game.snake().head().offset(Direction::Right);
+        game.place_food_for_test(food);
+
+        assert_eq!(game.step(), StepOutcome::AteFood);
+
+        assert_eq!(game.snake().head(), food);
+        assert_eq!(game.snake().segment_count(), original_len + 1);
+        assert_eq!(game.score(), 10);
+        assert_eq!(game.high_score(), 10);
+    }
+
+    #[test]
+    fn reversing_direction_in_one_tick_is_rejected() {
+        let mut game = Game::new();
+
+        assert!(!game.queue_turn(Direction::Left));
+        assert_eq!(game.snake().direction(), Direction::Right);
+
+        let head = game.snake().head();
+        game.step();
+
+        assert_eq!(game.snake().head(), head.offset(Direction::Right));
+    }
+
+    #[test]
+    fn quick_chained_turns_are_applied_on_consecutive_steps() {
+        let mut game = Game::new();
+        let head = game.snake().head();
+        game.place_food_for_test(Point::new(0, 0));
+
+        assert!(game.queue_turn(Direction::Up));
+        assert!(game.queue_turn(Direction::Left));
+
+        assert_eq!(game.step(), StepOutcome::Moved);
+        assert_eq!(game.snake().head(), head.offset(Direction::Up));
+
+        assert_eq!(game.step(), StepOutcome::Moved);
+        assert_eq!(
+            game.snake().head(),
+            head.offset(Direction::Up).offset(Direction::Left)
+        );
+    }
+
+    #[test]
+    fn queued_turns_are_validated_against_the_previous_queued_turn() {
+        let mut game = Game::new();
+
+        assert!(game.queue_turn(Direction::Up));
+        assert!(!game.queue_turn(Direction::Down));
+        assert!(game.queue_turn(Direction::Left));
+        assert!(!game.queue_turn(Direction::Down));
+    }
+
+    #[test]
+    fn wall_collision_ends_the_game() {
+        let mut game = Game::new();
+        let snake = VecDeque::from([Point::new(game.board().width() - 1, 0)]);
+        game.replace_snake_for_test(snake, Direction::Right);
+        game.place_food_for_test(Point::new(0, 0));
+
+        assert_eq!(game.step(), StepOutcome::Collision);
+        assert_eq!(game.status(), GameStatus::Playing);
+
+        game.end_after_collision();
+        assert_eq!(game.status(), GameStatus::GameOver);
+    }
+
+    #[test]
+    fn collision_can_be_corrected_by_a_late_valid_turn() {
+        let mut game = Game::new();
+        let snake = VecDeque::from([Point::new(game.board().width() - 1, 2)]);
+        game.replace_snake_for_test(snake, Direction::Right);
+        game.place_food_for_test(Point::new(0, 0));
+
+        assert_eq!(game.step(), StepOutcome::Collision);
+
+        assert!(game.queue_turn(Direction::Up));
+        assert_eq!(game.step(), StepOutcome::Moved);
+        assert_eq!(game.snake().head(), Point::new(game.board().width() - 1, 1));
+        assert_eq!(game.status(), GameStatus::Playing);
+    }
+
+    #[test]
+    fn self_collision_ends_the_game() {
+        let mut game = Game::new();
+        let snake = VecDeque::from([
+            Point::new(5, 5),
+            Point::new(5, 6),
+            Point::new(4, 6),
+            Point::new(4, 5),
+            Point::new(5, 5),
+        ]);
+        game.replace_snake_for_test(snake, Direction::Down);
+        game.place_food_for_test(Point::new(0, 0));
+
+        assert_eq!(game.step(), StepOutcome::Collision);
+        game.end_after_collision();
+        assert_eq!(game.status(), GameStatus::GameOver);
+    }
+
+    #[test]
+    fn restart_resets_game_and_preserves_high_score() {
+        let mut game = Game::new();
+        set_score(&mut game, 120);
+        game.end_game();
+
+        game.restart();
+
+        assert_eq!(game.status(), GameStatus::Playing);
+        assert_eq!(game.score(), 0);
+        assert_eq!(game.high_score(), 120);
+        assert_eq!(game.snake().segment_count(), STARTING_LENGTH);
+    }
+
+    #[test]
+    fn resizing_restarts_on_the_new_board_and_preserves_high_score() {
+        let mut game = Game::new();
+        set_score(&mut game, 120);
+
+        assert!(game.resize_board(Board::new(60, 40)));
+
+        assert_eq!(game.board(), Board::new(60, 40));
+        assert_eq!(game.status(), GameStatus::Playing);
+        assert_eq!(game.score(), 0);
+        assert_eq!(game.high_score(), 120);
+        assert!(
+            game.snake()
+                .segments()
+                .iter()
+                .all(|point| game.board().contains(*point))
+        );
+    }
+
+    #[test]
+    fn resizing_to_the_same_board_does_not_restart() {
+        let mut game = Game::new();
+        set_score(&mut game, 120);
+        let board = game.board();
+
+        assert!(!game.resize_board(board));
+
+        assert_eq!(game.score(), 120);
+    }
+
+    #[test]
+    fn resizing_to_a_board_that_cannot_fit_the_snake_does_not_restart() {
+        let mut game = Game::new();
+        set_score(&mut game, 120);
+
+        assert!(!game.resize_board(Board::new(5, 20)));
+
+        assert_eq!(
+            game.board(),
+            Board::new(DEFAULT_BOARD_WIDTH, DEFAULT_BOARD_HEIGHT)
+        );
+        assert_eq!(game.score(), 120);
+    }
+
+    #[test]
+    fn initial_step_duration_uses_the_base_speed() {
+        let game = Game::new();
+
+        assert_eq!(game.step_duration(), BASE_STEP_DURATION);
+    }
+
+    #[test]
+    fn level_is_derived_from_score_thresholds() {
+        let mut game = Game::new();
+        assert_eq!(game.level(), 1);
+
+        set_score(&mut game, POINTS_PER_LEVEL - 1);
+        assert_eq!(game.level(), 1);
+
+        set_score(&mut game, POINTS_PER_LEVEL);
+        assert_eq!(game.level(), 2);
+    }
+
+    #[test]
+    fn scoring_uses_the_level_before_food_is_added() {
+        let mut game = Game::new();
+        set_score(&mut game, POINTS_PER_LEVEL);
+        let food = game.snake().head().offset(Direction::Right);
+        game.place_food_for_test(food);
+
+        assert_eq!(game.step(), StepOutcome::AteFood);
+        assert_eq!(game.score(), POINTS_PER_LEVEL + POINTS_PER_FOOD * 2);
+        assert_eq!(game.level(), 2);
+    }
+
+    #[test]
+    fn movement_cadence_stops_at_the_minimum_duration() {
+        let mut game = Game::new();
+        set_score(&mut game, POINTS_PER_LEVEL * 100);
+
+        assert_eq!(game.step_duration(), MIN_STEP_DURATION);
+    }
+
+    #[test]
+    fn filling_the_board_ends_the_round_without_food() {
+        let mut game = Game::new_with_board_and_high_score(Board::new(6, 1), 0);
+        game.replace_snake_for_test(
+            VecDeque::from([
+                Point::new(4, 0),
+                Point::new(3, 0),
+                Point::new(2, 0),
+                Point::new(1, 0),
+                Point::new(0, 0),
+            ]),
+            Direction::Right,
+        );
+        game.place_food_for_test(Point::new(5, 0));
+
+        assert_eq!(game.step(), StepOutcome::AteFood);
+        assert_eq!(game.food(), None);
+        assert_eq!(game.status(), GameStatus::GameOver);
+    }
+}

--- a/examples/snake/game_loop.rs
+++ b/examples/snake/game_loop.rs
@@ -1,0 +1,457 @@
+//! Bevy systems that drive the snake game loop.
+//!
+//! The domain rules live in [`crate::game`]. These ordinary Bevy systems show how a
+//! `bevy_ratatui` application can connect terminal conditions to domain resources without putting
+//! behavior in the draw closure. [`apply_game_commands`] consumes translated input,
+//! [`sync_playfield`] derives state from [`bevy_ratatui::RatatuiContext`], and
+//! [`advance_game`] updates the model from Bevy time.
+//!
+//! The chained order in `main.rs` is meaningful: resize policy runs before commands, commands run
+//! before movement, and drawing happens later in [`PostUpdate`]. The movement timer itself is a
+//! Snake policy rather than a `bevy_ratatui` requirement. It preserves partial interpolation while
+//! paused, catches up a bounded number of logical steps after ordinary stalls, and stops while the
+//! terminal cannot display a valid board.
+//!
+//! Input forgiveness is intentional. Taneli Armanto, who created Nokia's 1997 Snake, described
+//! adding a tiny crash delay after testing showed that edge turns were frustratingly hard at speed.
+//! This example applies that idea when [`StepOutcome::Collision`] starts a short correction window.
+//! [`crate::snake::Snake`] separately buffers quick chained turns such as `Up, Left` so they are
+//! applied across consecutive movement steps instead of being consumed by one rendered frame.
+//!
+//! [Nokia's 1997 Snake]: https://www.itsnicethat.com/features/taneli-armanto-the-history-of-snake-design-legacies-230221
+
+use std::time::Duration;
+
+use bevy::{app::AppExit, prelude::*};
+
+use crate::{
+    controls::GameCommand,
+    game::{BASE_STEP_DURATION, Game, StepOutcome},
+    playfield::Playfield,
+};
+
+/// Input-forgiveness window after a movement step discovers a collision.
+///
+/// This duration is wall-clock time rather than a fraction of a movement step. Keeping it separate
+/// lets faster levels retain the same small opportunity to correct a near-edge turn. It is a game
+/// design choice inspired by [Nokia's 1997 Snake][snake-history], not timing required by Bevy or
+/// `bevy_ratatui`.
+///
+/// [snake-history]: https://www.itsnicethat.com/features/taneli-armanto-the-history-of-snake-design-legacies-230221
+const CRASH_GRACE_DURATION: Duration = Duration::from_millis(80);
+/// Maximum logical steps processed after one delayed render frame.
+///
+/// Repeating timers report every interval crossed by a frame. Processing a few of those intervals
+/// keeps movement speed stable through ordinary scheduling stalls, while the cap prevents a long
+/// terminal suspension or debugger stop from causing an unbounded burst of invisible moves.
+const MAX_CATCH_UP_STEPS: u32 = 4;
+
+/// Runtime timing for movement, interpolation, and collision forgiveness.
+///
+/// Rendering still happens every frame. The repeating movement timer gates whole-cell rule updates
+/// and supplies interpolation progress between them. The optional one-shot timer is also the single
+/// definition of whether collision grace is active; [`Game`] only reports the
+/// collision that starts it.
+#[derive(Debug, Resource)]
+pub struct GameTiming {
+    /// Repeating cadence for whole-cell movement.
+    movement: Timer,
+
+    /// Active wall-clock opportunity to correct the latest collision.
+    crash_grace: Option<Timer>,
+}
+
+impl GameTiming {
+    /// Returns the visible fraction of the current movement interval.
+    pub fn movement_progress(&self) -> f32 {
+        self.movement.fraction()
+    }
+
+    /// Returns whether a collision is waiting for correction or expiry.
+    pub fn crash_grace_active(&self) -> bool {
+        self.crash_grace.is_some()
+    }
+
+    /// Marks the latest logical movement as fully rendered.
+    ///
+    /// Collision does not update the snake's movement snapshot, so leaving a repeating timer at its
+    /// wrapped fraction would visually replay the preceding move during crash grace. Setting elapsed
+    /// time to the duration keeps the snake at the position where the collision was detected.
+    fn finish_interpolation(&mut self) {
+        let duration = self.movement.duration();
+        self.movement.set_elapsed(duration);
+    }
+
+    /// Advances movement time and returns a bounded number of completed logical steps.
+    fn tick_movement(&mut self, delta: Duration) -> u32 {
+        self.movement.tick(delta);
+        self.movement
+            .times_finished_this_tick()
+            .min(MAX_CATCH_UP_STEPS)
+    }
+
+    /// Starts the Nokia-inspired wall-clock opportunity to correct a collision.
+    fn start_crash_grace(&mut self) {
+        self.crash_grace = Some(Timer::new(CRASH_GRACE_DURATION, TimerMode::Once));
+    }
+
+    /// Advances active collision grace and consumes it when it expires this frame.
+    fn tick_crash_grace(&mut self, delta: Duration) -> bool {
+        let Some(timer) = self.crash_grace.as_mut() else {
+            return false;
+        };
+
+        timer.tick(delta);
+        let expired = timer.just_finished();
+        if expired {
+            self.finish_crash_grace();
+        }
+        expired
+    }
+
+    /// Ends the active collision-correction opportunity without changing game rules.
+    fn finish_crash_grace(&mut self) {
+        self.crash_grace = None;
+    }
+
+    /// Restarts all runtime timing at the cadence of a new or corrected round.
+    fn reset(&mut self, movement_duration: Duration) {
+        self.movement.set_duration(movement_duration);
+        self.movement.reset();
+        self.crash_grace = None;
+    }
+
+    /// Updates movement cadence after score progression changes the level.
+    fn set_movement_duration(&mut self, duration: Duration) {
+        self.movement.set_duration(duration);
+    }
+}
+
+impl Default for GameTiming {
+    fn default() -> Self {
+        Self {
+            movement: Timer::new(BASE_STEP_DURATION, TimerMode::Repeating),
+            crash_grace: None,
+        }
+    }
+}
+
+/// Applies high-level commands produced by the controls module in message order.
+///
+/// Restart resets runtime timing because the new snake has no previous movement to interpolate.
+/// Turns only update rule state; [`advance_game`] decides when queued turns become logical
+/// movement.
+pub fn apply_game_commands(
+    mut game: ResMut<Game>,
+    mut game_commands: MessageReader<GameCommand>,
+    mut exit: MessageWriter<AppExit>,
+    mut timing: ResMut<GameTiming>,
+) {
+    for command in game_commands.read() {
+        match command {
+            GameCommand::Turn(direction) => {
+                game.queue_turn(*direction);
+            }
+            GameCommand::TogglePause => game.toggle_pause(),
+            GameCommand::Restart => {
+                game.restart();
+                timing.reset(game.step_duration());
+            }
+            GameCommand::Quit => {
+                exit.write_default();
+            }
+        }
+    }
+}
+
+/// Keeps the logical board matched to the available terminal playfield.
+///
+/// Resizing restarts the current round because snake segments and food are board coordinates. The
+/// high score remains on the [`Game`] resource so resizing does not erase the session record.
+/// Invalid or temporarily unavailable terminal sizes are recorded as unavailable instead of
+/// changing [`Game::status`](crate::game::Game::status), allowing an explicit player pause to
+/// remain distinct from an environmental suspension.
+///
+/// `RatatuiContext::size` can fail while terminal access is unavailable, so the system converts
+/// both an error and an undersized terminal into `None`. Keeping that case in resource state lets
+/// later systems use a normal Bevy guard instead of attempting terminal I/O themselves.
+pub fn sync_playfield(
+    context: Res<bevy_ratatui::RatatuiContext>,
+    mut playfield: ResMut<Playfield>,
+    mut game: ResMut<Game>,
+    mut timing: ResMut<GameTiming>,
+) {
+    let board = playfield.update_for_size(context.size().ok());
+
+    if board.is_some_and(|board| game.resize_board(board)) {
+        timing.reset(game.step_duration());
+    }
+}
+
+/// Advances the game for movement intervals completed since the previous render frame.
+///
+/// Paused rounds and unavailable terminals leave runtime timing untouched, preserving visual
+/// progress until play resumes. A delayed frame may advance several cells, bounded by the
+/// `MAX_CATCH_UP_STEPS` policy. Collision instead finishes the preceding interpolation and starts
+/// the separate crash-grace clock. A buffered turn during grace must produce a valid move; another
+/// collision ends the round rather than repeatedly renewing grace.
+pub fn advance_game(
+    time: Res<Time>,
+    playfield: Res<Playfield>,
+    mut timing: ResMut<GameTiming>,
+    mut game: ResMut<Game>,
+) {
+    if !playfield.is_available() || !game.is_playing() {
+        return;
+    }
+
+    if timing.crash_grace_active() {
+        if game.snake().has_queued_turn() {
+            match game.step() {
+                StepOutcome::Moved | StepOutcome::AteFood => {
+                    timing.reset(game.step_duration());
+                }
+                StepOutcome::Collision => {
+                    timing.finish_crash_grace();
+                    game.end_after_collision();
+                }
+                StepOutcome::Noop => {}
+            }
+            return;
+        }
+
+        if timing.tick_crash_grace(time.delta()) {
+            game.end_after_collision();
+        }
+        return;
+    }
+
+    let completed_steps = timing.tick_movement(time.delta());
+    for _ in 0..completed_steps {
+        match game.step() {
+            StepOutcome::Moved | StepOutcome::AteFood => {}
+            StepOutcome::Collision => {
+                timing.finish_interpolation();
+                timing.start_crash_grace();
+                return;
+            }
+            StepOutcome::Noop => break,
+        }
+
+        if !game.is_playing() {
+            timing.finish_interpolation();
+            break;
+        }
+    }
+    timing.set_movement_duration(game.step_duration());
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use bevy_ratatui::event::KeyMessage;
+    use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use super::*;
+    use crate::{
+        controls::translate_keyboard_input,
+        game::GameStatus,
+        geometry::{Direction, Point},
+        playfield::Playfield,
+    };
+
+    /// Creates the available terminal condition needed by movement-system tests.
+    fn available_playfield() -> Playfield {
+        let mut playfield = Playfield::default();
+        playfield.update_for_size(Some(ratatui::layout::Size::new(100, 40)));
+        playfield
+    }
+
+    #[test]
+    fn terminal_key_message_reaches_the_game_as_a_buffered_turn() {
+        let mut app = App::new();
+        app.add_message::<KeyMessage>()
+            .add_message::<GameCommand>()
+            .add_message::<AppExit>()
+            .init_resource::<Game>()
+            .init_resource::<GameTiming>()
+            .add_systems(PreUpdate, translate_keyboard_input)
+            .add_systems(Update, apply_game_commands);
+        app.world_mut()
+            .write_message(KeyMessage(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)));
+
+        app.update();
+
+        assert!(app.world().resource::<Game>().snake().has_queued_turn());
+    }
+
+    #[test]
+    fn reset_restores_base_round_cadence_and_clears_grace() {
+        let mut game = Game::new();
+
+        let mut timing = GameTiming::default();
+        timing.set_movement_duration(Duration::from_millis(95));
+        timing.tick_movement(Duration::from_millis(95));
+        timing.start_crash_grace();
+        timing.tick_crash_grace(Duration::from_millis(40));
+
+        game.restart();
+        timing.reset(game.step_duration());
+
+        assert_eq!(timing.movement.duration(), BASE_STEP_DURATION);
+        assert_eq!(timing.movement.elapsed(), Duration::ZERO);
+        assert!(!timing.crash_grace_active());
+    }
+
+    #[test]
+    fn catch_up_steps_are_bounded_after_a_long_frame() {
+        let mut timing = GameTiming::default();
+        let completed_steps = timing.tick_movement(BASE_STEP_DURATION * 20);
+
+        assert_eq!(timing.movement.times_finished_this_tick(), 20);
+        assert_eq!(completed_steps, MAX_CATCH_UP_STEPS);
+    }
+
+    #[test]
+    fn collision_finishes_interpolation_before_grace() {
+        let mut game = Game::new();
+        let snake = VecDeque::from([Point::new(game.board().width() - 1, 0)]);
+        game.replace_snake_for_test(snake, Direction::Right);
+        game.place_food_for_test(Point::new(0, 0));
+
+        let mut timing = GameTiming::default();
+        let completed_steps = timing.tick_movement(BASE_STEP_DURATION);
+
+        for _ in 0..completed_steps {
+            if game.step() == StepOutcome::Collision {
+                timing.finish_interpolation();
+                timing.start_crash_grace();
+                break;
+            }
+        }
+
+        assert!(timing.crash_grace_active());
+        assert_eq!(timing.movement_progress(), 1.0);
+    }
+
+    #[test]
+    fn late_turn_that_still_collides_ends_the_round() {
+        let mut app = App::new();
+        let mut game = Game::new();
+        let corner = Point::new(game.board().width() - 1, 0);
+        game.replace_snake_for_test(VecDeque::from([corner]), Direction::Right);
+        game.place_food_for_test(Point::new(0, 1));
+        assert_eq!(game.step(), StepOutcome::Collision);
+        assert!(game.queue_turn(Direction::Up));
+
+        let mut timing = GameTiming::default();
+        timing.start_crash_grace();
+
+        app.insert_resource(game)
+            .insert_resource(timing)
+            .insert_resource(available_playfield())
+            .init_resource::<Time>()
+            .add_systems(Update, advance_game);
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<Game>().status(),
+            GameStatus::GameOver
+        );
+        assert!(!app.world().resource::<GameTiming>().crash_grace_active());
+    }
+
+    #[test]
+    fn paused_game_preserves_partial_interpolation() {
+        let mut app = App::new();
+        let mut timing = GameTiming::default();
+        timing.tick_movement(Duration::from_millis(70));
+        let elapsed = timing.movement.elapsed();
+
+        let mut game = Game::new();
+        game.toggle_pause();
+        app.insert_resource(game)
+            .insert_resource(timing)
+            .insert_resource(available_playfield())
+            .init_resource::<Time>()
+            .add_systems(Update, advance_game);
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<GameTiming>().movement.elapsed(),
+            elapsed
+        );
+    }
+
+    #[test]
+    fn unavailable_terminal_suspends_movement() {
+        let mut app = App::new();
+        let game = Game::new();
+        let head = game.snake().head();
+        let mut time = Time::<()>::default();
+        time.advance_by(BASE_STEP_DURATION);
+
+        app.insert_resource(game)
+            .init_resource::<GameTiming>()
+            .init_resource::<Playfield>()
+            .insert_resource(time)
+            .add_systems(Update, advance_game);
+
+        app.update();
+
+        assert_eq!(app.world().resource::<Game>().snake().head(), head);
+        assert_eq!(
+            app.world().resource::<GameTiming>().movement.elapsed(),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn delayed_frame_advances_each_completed_interval() {
+        let mut app = App::new();
+        let mut game = Game::new();
+        let head = game.snake().head();
+        game.place_food_for_test(Point::new(0, 0));
+        let mut time = Time::<()>::default();
+        time.advance_by(BASE_STEP_DURATION * 3);
+
+        app.insert_resource(game)
+            .init_resource::<GameTiming>()
+            .insert_resource(available_playfield())
+            .insert_resource(time)
+            .add_systems(Update, advance_game);
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<Game>().snake().head(),
+            Point::new(head.x + 3, head.y)
+        );
+    }
+
+    #[test]
+    fn expired_crash_grace_ends_the_round() {
+        let mut app = App::new();
+        let mut timing = GameTiming::default();
+        timing.start_crash_grace();
+        let mut time = Time::<()>::default();
+        time.advance_by(CRASH_GRACE_DURATION);
+
+        app.init_resource::<Game>()
+            .insert_resource(timing)
+            .insert_resource(available_playfield())
+            .insert_resource(time)
+            .add_systems(Update, advance_game);
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<Game>().status(),
+            GameStatus::GameOver
+        );
+        assert!(!app.world().resource::<GameTiming>().crash_grace_active());
+    }
+}

--- a/examples/snake/geometry.rs
+++ b/examples/snake/geometry.rs
@@ -1,0 +1,115 @@
+//! Board geometry and movement directions.
+//!
+//! These types are deliberately small value types. The rule layer stores snake segments as
+//! [`Point`] values on a [`Board`], controls produce [`Direction`] values, and the terminal layer
+//! decides how those logical cells map to terminal pixels.
+
+/// Cardinal movement direction for the snake.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Direction {
+    /// Decreases the board row.
+    Up,
+    /// Increases the board row.
+    Down,
+    /// Decreases the board column.
+    Left,
+    /// Increases the board column.
+    Right,
+}
+
+impl Direction {
+    /// Returns whether two directions would immediately reverse the snake.
+    pub fn is_opposite(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Up, Self::Down)
+                | (Self::Down, Self::Up)
+                | (Self::Left, Self::Right)
+                | (Self::Right, Self::Left)
+        )
+    }
+}
+
+/// Logical board dimensions in snake cells.
+///
+/// The terminal renderer decides how these logical cells map onto terminal cells.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Board {
+    /// Number of logical snake cells from left to right.
+    width: i16,
+
+    /// Number of logical snake cells from top to bottom.
+    height: i16,
+}
+
+impl Board {
+    /// Creates a board with positive logical dimensions.
+    ///
+    /// Use [`Self::try_new`] when dimensions come from an external source rather than constants or
+    /// other already-validated application state.
+    ///
+    /// # Panics
+    ///
+    /// Panics when either dimension is zero or negative.
+    pub fn new(width: i16, height: i16) -> Self {
+        Self::try_new(width, height).expect("board dimensions must be positive")
+    }
+
+    /// Creates a board when both logical dimensions are positive.
+    pub fn try_new(width: i16, height: i16) -> Option<Self> {
+        (width > 0 && height > 0).then_some(Self { width, height })
+    }
+
+    /// Returns the number of logical cells from left to right.
+    pub fn width(self) -> i16 {
+        self.width
+    }
+
+    /// Returns the number of logical cells from top to bottom.
+    pub fn height(self) -> i16 {
+        self.height
+    }
+
+    /// Returns whether `point` is inside the board bounds.
+    pub fn contains(self, point: Point) -> bool {
+        point.x >= 0 && point.y >= 0 && point.x < self.width && point.y < self.height
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_constructor_rejects_non_positive_dimensions() {
+        assert_eq!(Board::try_new(0, 20), None);
+        assert_eq!(Board::try_new(20, 0), None);
+        assert_eq!(Board::try_new(-1, 20), None);
+    }
+}
+
+/// Coordinate in logical board cells.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Point {
+    /// Zero-based logical column, increasing to the right.
+    pub x: i16,
+    /// Zero-based logical row, increasing downward with terminal coordinates.
+    pub y: i16,
+}
+
+impl Point {
+    /// Creates a point at `x, y`.
+    pub fn new(x: i16, y: i16) -> Self {
+        Self { x, y }
+    }
+
+    /// Returns the neighboring point reached by moving one cell in `direction`.
+    pub fn offset(self, direction: Direction) -> Self {
+        match direction {
+            Direction::Up => Self::new(self.x, self.y - 1),
+            Direction::Down => Self::new(self.x, self.y + 1),
+            Direction::Left => Self::new(self.x - 1, self.y),
+            Direction::Right => Self::new(self.x + 1, self.y),
+        }
+    }
+}

--- a/examples/snake/hud.rs
+++ b/examples/snake/hud.rs
@@ -1,0 +1,140 @@
+//! Heads-up display and overlay widgets.
+//!
+//! The board renderer owns game cells. This module owns the text around the board: score/status,
+//! controls, pause and game-over overlays, and the small-terminal fallback.
+
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Rect},
+    style::{Color, Stylize},
+    text::{Line, Text},
+    widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap},
+};
+
+use crate::game::{Game, GameStatus};
+
+/// Draws score, level, length, and state.
+pub fn render_hud(game: &Game, crash_grace_active: bool, area: Rect, buf: &mut Buffer) {
+    let line = Line::from_iter([
+        " Snake ".black().on_green(),
+        "  ".into(),
+        format!("Score: {}", game.score()).yellow(),
+        "  ".into(),
+        format!("High: {}", game.high_score()).into(),
+        "  ".into(),
+        format!("Level: {}", game.level()).into(),
+        "  ".into(),
+        format!("Length: {}", game.snake().segment_count()).into(),
+        "  ".into(),
+        status_label(game, crash_grace_active).fg(status_color(game.status())),
+    ]);
+
+    Paragraph::new(line)
+        .block(Block::new().borders(Borders::BOTTOM))
+        .centered()
+        .render(area, buf);
+}
+
+/// Draws the control strip below the board.
+pub fn render_controls(area: Rect, buf: &mut Buffer) {
+    let controls = Line::from_iter([
+        "Move: ".into(),
+        "Arrows/WASD".cyan(),
+        "   Pause: ".into(),
+        "Space/P".cyan(),
+        "   Restart: ".into(),
+        "R".cyan(),
+        "   Quit: ".into(),
+        "Q/Esc".cyan(),
+    ]);
+
+    Paragraph::new(controls)
+        .centered()
+        .block(Block::new().borders(Borders::TOP))
+        .render(area, buf);
+}
+
+/// Draws the pause or game-over overlay.
+pub fn render_overlay(title: &str, message: &str, area: Rect, buf: &mut Buffer) {
+    let overlay = centered_rect(34, 5, area);
+    Clear.render(overlay, buf);
+
+    let text = Text::from_iter([
+        Line::from(title).bold().centered(),
+        Line::default(),
+        Line::from(message).centered(),
+    ]);
+
+    Paragraph::new(text)
+        .block(Block::bordered().border_style(Color::Yellow))
+        .white()
+        .on_black()
+        .centered()
+        .wrap(Wrap { trim: true })
+        .render(overlay, buf);
+}
+
+/// Draws the fallback message when the terminal cannot fit the board.
+pub fn render_too_small(area: Rect, buf: &mut Buffer, min_width: u16, min_height: u16) {
+    let text = Text::from_iter([
+        Line::from("Terminal too small").bold().centered(),
+        Line::default(),
+        Line::from(format!("Snake needs at least {min_width}x{min_height}.")).centered(),
+    ]);
+
+    Paragraph::new(text)
+        .centered()
+        .wrap(Wrap { trim: true })
+        .render(area, buf);
+}
+
+/// Centers a requested overlay while clamping it to the available terminal area.
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    area.centered(Constraint::Length(width), Constraint::Length(height))
+}
+
+/// Maps lifecycle state to a compact HUD signal without affecting board colors.
+fn status_color(status: GameStatus) -> Color {
+    match status {
+        GameStatus::Playing => Color::Green,
+        GameStatus::Paused => Color::Yellow,
+        GameStatus::GameOver => Color::Red,
+    }
+}
+
+/// Gives crash grace precedence while playing because immediate input matters.
+fn status_label(game: &Game, crash_grace_active: bool) -> &'static str {
+    if game.status() == GameStatus::Playing && crash_grace_active {
+        "Turn now"
+    } else {
+        match game.status() {
+            GameStatus::Playing => "Playing",
+            GameStatus::Paused => "Paused",
+            GameStatus::GameOver => "Game over",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlay_area_is_centered_and_clamped_to_the_terminal() {
+        let area = Rect::new(10, 20, 40, 9);
+
+        assert_eq!(centered_rect(34, 5, area), Rect::new(13, 22, 34, 5));
+        assert_eq!(centered_rect(80, 24, area), area);
+    }
+
+    #[test]
+    fn grace_only_overrides_the_playing_status() {
+        let mut game = Game::new();
+        assert_eq!(status_label(&game, true), "Turn now");
+
+        game.end_after_collision();
+        assert_eq!(status_label(&game, true), "Game over");
+    }
+}

--- a/examples/snake/main.rs
+++ b/examples/snake/main.rs
@@ -1,0 +1,80 @@
+//! A complete `bevy_ratatui` application organized around Bevy schedules and resources.
+//!
+//! Run it with:
+//!
+//! ```sh
+//! cargo run --example snake
+//! ```
+//!
+//! The app follows a reusable terminal-application flow. [`RatatuiPlugins`] owns terminal setup and
+//! emits input messages. [`PreUpdate`] translates those messages into application intent, chained
+//! [`Update`] systems mutate resources in a known order, and [`PostUpdate`] draws the resulting
+//! state through [`bevy_ratatui::RatatuiContext`]. Keeping drawing last means widgets only project
+//! state; they do not become another owner of application behavior.
+//!
+//! Start with the four modules that show the reusable `bevy_ratatui` integration:
+//!
+//! - [`controls`] translates terminal key messages into game commands.
+//! - [`game_loop`] connects Bevy time, commands, and terminal resize events to the rules.
+//! - [`terminal`] projects the current game state into Ratatui widgets and cells.
+//! - [`main`](crate) wires those systems into Bevy schedules.
+//!
+//! The remaining modules keep game-specific detail out of that path:
+//!
+//! - [`game`], [`snake`], and [`geometry`] own framework-independent rules and values.
+//! - [`playfield`] shares terminal-derived board availability between update and rendering.
+//! - [`hud`] renders text widgets around the board.
+//! - [`terminal_cells`] renders stable logical game cells to terminal cells.
+//! - [`snake_rendering`] renders stable segments and smoothly moving ends.
+
+#![warn(rustdoc::broken_intra_doc_links)]
+
+pub mod controls;
+pub mod game;
+pub mod game_loop;
+pub mod geometry;
+pub mod hud;
+pub mod playfield;
+pub mod snake;
+pub mod snake_rendering;
+pub mod terminal;
+pub mod terminal_cells;
+
+use std::time::Duration;
+
+use bevy::{app::ScheduleRunnerPlugin, prelude::*};
+use bevy_ratatui::{RatatuiPlugins, event::InputSet};
+use controls::{GameCommand, translate_keyboard_input};
+use game::Game;
+use game_loop::{GameTiming, advance_game, apply_game_commands, sync_playfield};
+use playfield::Playfield;
+use terminal::draw_terminal;
+
+/// Builds the terminal app and assigns input, state updates, and drawing to separate schedules.
+///
+/// `ScheduleRunnerPlugin` supplies a regular frame cadence without Bevy's window stack. The 60 FPS
+/// frame rate keeps terminal input and partial-cell rendering responsive, while
+/// [`game_loop::GameTiming`] demonstrates that application updates can use their own slower
+/// cadence.
+fn main() {
+    let translate_input = translate_keyboard_input.in_set(InputSet::Post);
+
+    App::new()
+        .add_plugins((
+            MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f32(
+                1. / 60.,
+            ))),
+            RatatuiPlugins::default(),
+        ))
+        .init_resource::<Game>()
+        .init_resource::<GameTiming>()
+        .init_resource::<Playfield>()
+        .add_message::<GameCommand>()
+        .add_systems(PreUpdate, translate_input)
+        .add_systems(
+            Update,
+            (sync_playfield, apply_game_commands, advance_game).chain(),
+        )
+        .add_systems(PostUpdate, draw_terminal)
+        .run();
+}

--- a/examples/snake/playfield.rs
+++ b/examples/snake/playfield.rs
@@ -1,0 +1,122 @@
+//! Terminal-derived playfield size and availability.
+//!
+//! [`Game`](crate::game::Game) stores the logical [`Board`] on which the current round was created.
+//! [`Playfield`] separately records whether the terminal can currently display that board. Sharing
+//! this environmental state as a Bevy resource lets update and draw systems follow the same policy
+//! without performing terminal I/O in the rule or rendering paths.
+
+use bevy::prelude::*;
+use ratatui::layout::Size;
+
+use crate::{geometry::Board, terminal_cells::TERMINAL_COLUMNS_PER_CELL};
+
+/// Rows reserved above the playfield for score and round state.
+pub const HUD_HEIGHT: u16 = 3;
+
+/// Rows reserved below the playfield for controls.
+pub const CONTROLS_HEIGHT: u16 = 3;
+
+/// Combined horizontal or vertical space consumed by both sides of the board border.
+const BOARD_BORDER: u16 = 2;
+
+/// Smallest logical width that leaves steering room and enough columns for the fixed UI.
+///
+/// Thirty double-width cells plus the border produce 62 terminal columns; the controls need 61.
+const MIN_BOARD_WIDTH: u16 = 30;
+
+/// Smallest logical height that leaves useful room to steer the starting snake.
+const MIN_BOARD_HEIGHT: u16 = 20;
+
+/// Smallest terminal width that fits both the logical board and fixed surrounding UI.
+pub const MIN_TERMINAL_WIDTH: u16 = MIN_BOARD_WIDTH * TERMINAL_COLUMNS_PER_CELL + BOARD_BORDER;
+
+/// Smallest terminal height after accounting for fixed UI rows, borders, and the board.
+pub const MIN_TERMINAL_HEIGHT: u16 = HUD_HEIGHT + CONTROLS_HEIGHT + BOARD_BORDER + MIN_BOARD_HEIGHT;
+
+/// Playable logical grid currently available from the terminal.
+///
+/// A temporary resize below the minimum records `None` instead of changing the player's pause
+/// state or killing the snake behind the fallback message. The current round can therefore resume
+/// when a usable terminal area returns.
+#[derive(Debug, Default, Resource)]
+pub struct Playfield {
+    /// Board dimensions available from the terminal, or `None` while it is too small or
+    /// unavailable.
+    current: Option<Board>,
+}
+
+impl Playfield {
+    /// Updates availability from the terminal size observed this frame.
+    ///
+    /// `None` also represents a failed terminal size query. Returning the resulting board lets the
+    /// coordinating system restart the round only when playable dimensions actually changed.
+    pub fn update_for_size(&mut self, size: Option<Size>) -> Option<Board> {
+        self.current = size.and_then(|size| board_for_terminal_size(size.width, size.height));
+        self.current
+    }
+
+    /// Returns whether the terminal can currently display and advance the round.
+    pub fn is_available(&self) -> bool {
+        self.current.is_some()
+    }
+}
+
+/// Returns the logical board that fits inside the terminal.
+///
+/// Each logical board cell is rendered as two terminal columns and one terminal row. This keeps the
+/// board smaller than half-block mode while making horizontal and vertical movement closer in
+/// physical size.
+fn board_for_terminal_size(width: u16, height: u16) -> Option<Board> {
+    if width < MIN_TERMINAL_WIDTH || height < MIN_TERMINAL_HEIGHT {
+        return None;
+    }
+
+    let board_width = width.checked_sub(BOARD_BORDER)? / TERMINAL_COLUMNS_PER_CELL;
+    let board_rows = height.checked_sub(HUD_HEIGHT + CONTROLS_HEIGHT + BOARD_BORDER)?;
+
+    let board_width = i16::try_from(board_width).ok()?;
+    let board_rows = i16::try_from(board_rows).ok()?;
+    Board::try_new(board_width, board_rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_size_maps_to_double_width_board() {
+        assert_eq!(board_for_terminal_size(100, 40), Some(Board::new(49, 32)));
+    }
+
+    #[test]
+    fn minimum_size_fits_the_board_and_fixed_ui() {
+        assert_eq!(
+            board_for_terminal_size(MIN_TERMINAL_WIDTH, MIN_TERMINAL_HEIGHT),
+            Some(Board::new(30, 20))
+        );
+        assert_eq!(
+            board_for_terminal_size(MIN_TERMINAL_WIDTH - 1, MIN_TERMINAL_HEIGHT),
+            None
+        );
+    }
+
+    #[test]
+    fn small_terminals_do_not_create_a_board() {
+        assert_eq!(board_for_terminal_size(20, 15), None);
+    }
+
+    #[test]
+    fn dimensions_larger_than_the_board_coordinate_type_are_rejected() {
+        assert_eq!(board_for_terminal_size(100, u16::MAX), None);
+    }
+
+    #[test]
+    fn unavailable_size_clears_playfield_availability() {
+        let mut playfield = Playfield::default();
+        playfield.update_for_size(Some(Size::new(100, 40)));
+        assert!(playfield.is_available());
+
+        playfield.update_for_size(None);
+        assert!(!playfield.is_available());
+    }
+}

--- a/examples/snake/snake.rs
+++ b/examples/snake/snake.rs
@@ -1,0 +1,309 @@
+//! Logical snake state and movement.
+//!
+//! A snake is more than its occupied cells: its direction, accepted future turns, and latest
+//! movement must change together. Keeping those invariants on [`Snake`] lets [`crate::game::Game`]
+//! coordinate board, food, and scoring rules without also managing the representation of movement.
+//!
+//! Rendering reads [`MovementSnapshot`] to interpolate the moving ends. Collision rules only read
+//! the current segments, preserving a whole-cell simulation regardless of frame rate.
+
+use std::collections::VecDeque;
+
+use crate::geometry::{Board, Direction, Point};
+
+/// Number of contiguous cells in a new snake.
+pub const STARTING_LENGTH: usize = 4;
+
+/// Number of future turns retained between logical movement steps.
+///
+/// Two entries preserve a quick corner such as `Up, Left`. A longer queue would make the snake
+/// execute old input after the player can no longer see why it was accepted.
+const MAX_QUEUED_TURNS: usize = 2;
+
+/// Snake geometry and the input needed to advance it.
+///
+/// Segments are ordered from head to tail. [`MovementSnapshot`] records only the endpoints needed
+/// for interpolation; movement and collision always use `segments`. At most one queued turn is
+/// applied per logical step so quick corners remain responsive without collapsing several inputs
+/// into one move.
+#[derive(Debug)]
+pub struct Snake {
+    /// Cells occupied after the latest successful logical step.
+    segments: VecDeque<Point>,
+
+    /// Endpoints occupied before the latest successful logical step.
+    movement: MovementSnapshot,
+
+    /// Direction applied by the latest logical step.
+    direction: Direction,
+
+    /// Accepted future turns, ordered by the steps on which they will be applied.
+    queued_turns: VecDeque<Direction>,
+}
+
+/// Previous endpoints needed to interpolate one successful logical movement.
+///
+/// The head moves on every successful step. `previous_tail` is present only when the tail also
+/// moved; growth leaves the tail stationary and therefore needs no tail interpolation. This compact
+/// snapshot avoids cloning the complete body for rendering.
+#[derive(Clone, Copy, Debug)]
+pub struct MovementSnapshot {
+    /// Head position before the latest successful step.
+    previous_head: Point,
+
+    /// Tail position before the latest step, when that step moved the tail.
+    previous_tail: Option<Point>,
+}
+
+impl MovementSnapshot {
+    /// Returns the head position before the latest successful step.
+    pub fn previous_head(self) -> Point {
+        self.previous_head
+    }
+
+    /// Returns the prior tail position when the latest step moved the tail.
+    pub fn previous_tail(self) -> Option<Point> {
+        self.previous_tail
+    }
+}
+
+impl Snake {
+    /// Returns whether `board` can contain the initial horizontal snake.
+    pub fn can_start_on(board: Board) -> bool {
+        let head_x = board.width() / 2;
+        head_x >= STARTING_LENGTH as i16 - 1
+    }
+
+    /// Creates a right-facing snake centered on `board`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when [`Self::can_start_on`] is false. Terminal-derived boards are substantially wider
+    /// than this minimum; callers accepting arbitrary boards should check before restarting.
+    pub fn new(board: Board) -> Self {
+        assert!(
+            Self::can_start_on(board),
+            "board must fit the starting snake"
+        );
+        let head = Point::new(board.width() / 2, board.height() / 2);
+        let segments = (0..STARTING_LENGTH as i16)
+            .map(|offset| Point::new(head.x - offset, head.y))
+            .collect::<VecDeque<_>>();
+        let tail = segments.back().copied();
+
+        Self {
+            movement: MovementSnapshot {
+                previous_head: head,
+                previous_tail: tail,
+            },
+            segments,
+            direction: Direction::Right,
+            queued_turns: VecDeque::new(),
+        }
+    }
+
+    /// Queues a non-reversing turn for a future logical step.
+    ///
+    /// Validation uses the newest queued turn when one exists. This accepts
+    /// `Right -> Up -> Left` but rejects `Right -> Up -> Down`, which would reverse the second turn
+    /// before it had been rendered.
+    pub fn queue_turn(&mut self, direction: Direction) -> bool {
+        if self.queued_turns.len() >= MAX_QUEUED_TURNS {
+            return false;
+        }
+
+        let previous_direction = self.queued_turns.back().copied().unwrap_or(self.direction);
+        if direction == previous_direction || direction.is_opposite(previous_direction) {
+            return false;
+        }
+
+        self.queued_turns.push_back(direction);
+        true
+    }
+
+    /// Applies at most one queued turn before the next logical movement.
+    pub fn apply_next_turn(&mut self) {
+        if let Some(direction) = self.queued_turns.pop_front() {
+            self.direction = direction;
+        }
+    }
+
+    /// Returns the head position proposed by the current direction.
+    pub fn next_head(&self) -> Point {
+        self.head().offset(self.direction)
+    }
+
+    /// Commits a collision-free move to `next_head` and optionally keeps the tail for growth.
+    pub fn advance(&mut self, next_head: Point, grows: bool) {
+        let previous_head = self.head();
+        let previous_tail = if !grows && self.segments.len() > 1 {
+            self.segments.back().copied()
+        } else {
+            None
+        };
+        self.movement = MovementSnapshot {
+            previous_head,
+            previous_tail,
+        };
+
+        self.segments.push_front(next_head);
+        if !grows {
+            self.segments.pop_back();
+        }
+    }
+
+    /// Returns whether `point` intersects body that would survive the proposed move.
+    ///
+    /// Entering the current tail cell is legal when the tail advances. Growth keeps the tail in
+    /// place, so every current segment remains collidable on that step.
+    pub fn would_collide(&self, point: Point, grows: bool) -> bool {
+        let collidable_segments = if grows {
+            self.segments.len()
+        } else {
+            self.segments.len().saturating_sub(1)
+        };
+
+        self.segments
+            .iter()
+            .take(collidable_segments)
+            .any(|segment| *segment == point)
+    }
+
+    /// Returns the current segments from head to tail.
+    pub fn segments(&self) -> &VecDeque<Point> {
+        &self.segments
+    }
+
+    /// Returns the endpoints before the latest successful logical step.
+    pub fn movement(&self) -> MovementSnapshot {
+        self.movement
+    }
+
+    /// Returns the current head.
+    pub fn head(&self) -> Point {
+        self.segments
+            .front()
+            .copied()
+            .expect("snake always has a head")
+    }
+
+    /// Returns the direction used by the latest logical step.
+    pub fn direction(&self) -> Direction {
+        self.direction
+    }
+
+    /// Returns the number of occupied body cells, including the head.
+    pub fn segment_count(&self) -> usize {
+        self.segments.len()
+    }
+
+    /// Returns whether any segment occupies `point`.
+    pub fn contains(&self, point: Point) -> bool {
+        self.segments.iter().any(|segment| *segment == point)
+    }
+
+    /// Returns whether a queued turn is waiting for a logical step.
+    pub fn has_queued_turn(&self) -> bool {
+        !self.queued_turns.is_empty()
+    }
+}
+
+#[cfg(test)]
+impl Snake {
+    /// Replaces the path and direction while restoring movement invariants for focused tests.
+    pub fn replace_segments_for_test(&mut self, segments: VecDeque<Point>, direction: Direction) {
+        let previous_head = segments
+            .front()
+            .copied()
+            .expect("test snake must have a head");
+        let previous_tail = if segments.len() > 1 {
+            segments.back().copied()
+        } else {
+            None
+        };
+        self.movement = MovementSnapshot {
+            previous_head,
+            previous_tail,
+        };
+        self.segments = segments;
+        self.direction = direction;
+        self.queued_turns.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_snake_is_contiguous_and_inside_the_board() {
+        let board = Board::new(24, 20);
+        let snake = Snake::new(board);
+
+        assert_eq!(snake.segment_count(), STARTING_LENGTH);
+        assert!(snake.segments().iter().all(|point| board.contains(*point)));
+        assert!(
+            snake
+                .segments()
+                .iter()
+                .zip(snake.segments().iter().skip(1))
+                .all(|(left, right)| left.x == right.x + 1 && left.y == right.y)
+        );
+    }
+
+    #[test]
+    fn starting_snake_requires_enough_space_left_of_center() {
+        assert!(!Snake::can_start_on(Board::new(5, 20)));
+        assert!(Snake::can_start_on(Board::new(6, 20)));
+    }
+
+    #[test]
+    fn queued_turns_are_applied_one_step_at_a_time() {
+        let mut snake = Snake::new(Board::new(24, 20));
+        assert!(snake.queue_turn(Direction::Up));
+        assert!(snake.queue_turn(Direction::Left));
+
+        snake.apply_next_turn();
+        let first_head = snake.next_head();
+        snake.advance(first_head, false);
+        assert_eq!(snake.direction(), Direction::Up);
+
+        snake.apply_next_turn();
+        let second_head = snake.next_head();
+        snake.advance(second_head, false);
+        assert_eq!(snake.direction(), Direction::Left);
+    }
+
+    #[test]
+    fn ordinary_movement_records_both_previous_endpoints() {
+        let mut snake = Snake::new(Board::new(24, 20));
+        let previous_head = snake.head();
+        let previous_tail = snake.segments().back().copied();
+
+        snake.advance(snake.next_head(), false);
+
+        assert_eq!(snake.movement().previous_head(), previous_head);
+        assert_eq!(snake.movement().previous_tail(), previous_tail);
+    }
+
+    #[test]
+    fn growth_records_that_the_tail_did_not_move() {
+        let mut snake = Snake::new(Board::new(24, 20));
+
+        snake.advance(snake.next_head(), true);
+
+        assert_eq!(snake.movement().previous_tail(), None);
+    }
+
+    #[test]
+    fn queue_rejects_duplicates_reversals_and_excess_turns() {
+        let mut snake = Snake::new(Board::new(24, 20));
+
+        assert!(!snake.queue_turn(Direction::Right));
+        assert!(!snake.queue_turn(Direction::Left));
+        assert!(snake.queue_turn(Direction::Up));
+        assert!(!snake.queue_turn(Direction::Down));
+        assert!(snake.queue_turn(Direction::Left));
+        assert!(!snake.queue_turn(Direction::Down));
+    }
+}

--- a/examples/snake/snake_rendering.rs
+++ b/examples/snake/snake_rendering.rs
@@ -1,0 +1,414 @@
+//! Complete terminal rendering for the snake.
+//!
+//! Game rules move the snake in whole [`Point`] cells. This module paints stable middle segments
+//! and draws the head and tail partway between logical cells. Keeping those choices together makes
+//! the growth exception and moving-end underlay policy visible without teaching terminal layout
+//! about the representation of [`Snake`].
+
+use ratatui::{buffer::Buffer, layout::Rect, style::Color};
+
+use crate::{
+    geometry::Point,
+    snake::Snake,
+    terminal_cells::{
+        BODY_COLOR, HEAD_COLOR, TERMINAL_COLUMNS_PER_CELL, Underlay, render_bottom_fraction,
+        render_full_cell, render_left_fraction, render_right_fraction, render_snake_cell,
+        render_top_fraction, render_underlay_cell,
+    },
+};
+
+/// Renders stable body cells and independently interpolated head and tail cells.
+///
+/// Growth leaves the previous and current paths at different lengths, so the new tail remains a
+/// stable full cell for that interval instead of interpolating between segments that do not
+/// correspond. Middle segments always remain stable because independently rounding every corner
+/// makes turns shimmer between frames.
+pub fn render_snake(snake: &Snake, movement_progress: f32, board: Rect, buf: &mut Buffer) {
+    let movement = snake.movement();
+    let segments = snake.segments();
+    let previous_tail = movement.previous_tail();
+    let smooth_tail = previous_tail.is_some();
+    let tail_index = segments.len().saturating_sub(1);
+
+    for (index, segment) in segments.iter().enumerate().rev() {
+        if index == 0 || smooth_tail && index == tail_index {
+            continue;
+        }
+
+        render_snake_cell(buf, board.x, board.y, BODY_COLOR, *segment);
+    }
+
+    if let Some(previous) = previous_tail {
+        let current_tail = segments.back().copied();
+        if let Some(current) = current_tail {
+            render_moving_snake_tail(buf, board.x, board.y, previous, current, movement_progress);
+        }
+    }
+
+    if let Some(head) = segments.front().copied() {
+        let previous = movement.previous_head();
+        render_moving_snake_head(buf, board.x, board.y, previous, head, movement_progress);
+    }
+}
+
+/// Renders the snake head between two logical board cells.
+///
+/// The head is a two-column by one-row logical cell. During a movement tick this function computes
+/// the fractional terminal cells covered by that rectangle and paints them with eighth-block
+/// glyphs. The body is not drawn here because rounded body interpolation makes turns shimmer.
+fn render_moving_snake_head(
+    buf: &mut Buffer,
+    board_x: u16,
+    board_y: u16,
+    previous: Point,
+    current: Point,
+    progress: f32,
+) {
+    let motion = EndMotion::head(previous, current, progress);
+    render_moving_segment(buf, board_x, board_y, motion);
+}
+
+/// Renders the snake tail between two logical board cells.
+///
+/// The tail uses the same coverage projection as the head. Its old cell reveals the board
+/// background as it contracts, while its current cell keeps a body underlay so the tail stays
+/// visually connected to the stable body.
+fn render_moving_snake_tail(
+    buf: &mut Buffer,
+    board_x: u16,
+    board_y: u16,
+    previous: Point,
+    current: Point,
+    progress: f32,
+) {
+    let motion = EndMotion::tail(previous, current, progress);
+    render_moving_segment(buf, board_x, board_y, motion);
+}
+
+/// Logical movement being projected between two rendered snake positions.
+///
+/// Grouping geometry with its complete paint policy keeps the horizontal and vertical renderers
+/// focused on axis-specific coverage. Head and tail constructors make their different underlays
+/// visible once instead of routing each paint decision through another enum. Terminal origins and
+/// buffer access remain function arguments because they are rendering effects, not properties of a
+/// snake's movement.
+#[derive(Clone, Copy, Debug)]
+struct EndMotion {
+    /// Snake cell occupied before the latest logical step.
+    previous: Point,
+    /// Snake cell occupied after the latest logical step.
+    current: Point,
+    /// Fraction of the logical step visible in this frame.
+    progress: f32,
+    /// Color painted by full and partial cells.
+    color: Color,
+    /// Surface revealed in the cell this end leaves.
+    previous_underlay: Underlay,
+    /// Surface already present in the cell this end enters.
+    current_underlay: Underlay,
+}
+
+impl EndMotion {
+    /// Creates head motion over body in the old cell and board in the new cell.
+    fn head(previous: Point, current: Point, progress: f32) -> Self {
+        Self {
+            previous,
+            current,
+            progress: progress.clamp(0.0, 1.0),
+            color: HEAD_COLOR,
+            previous_underlay: Underlay::Body,
+            current_underlay: Underlay::board(current),
+        }
+    }
+
+    /// Creates tail motion that reveals board while staying connected to the body ahead.
+    fn tail(previous: Point, current: Point, progress: f32) -> Self {
+        Self {
+            previous,
+            current,
+            progress: progress.clamp(0.0, 1.0),
+            color: BODY_COLOR,
+            previous_underlay: Underlay::board(previous),
+            current_underlay: Underlay::Body,
+        }
+    }
+}
+
+/// Coverage of one terminal cell along either movement axis.
+///
+/// The axis-specific renderer decides whether leading and trailing mean left and right or top and
+/// bottom. Keeping that distinction at the paint boundary lets the interpolation math stay shared.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Coverage {
+    /// The moving segment covers the whole terminal cell.
+    Full,
+    /// The segment covers the start of the axis by this many eighths.
+    Leading(u8),
+    /// The segment covers the end of the axis by this many eighths.
+    Trailing(u8),
+}
+
+impl Coverage {
+    /// Computes the visible portion of one unit cell touched by a moving span.
+    fn for_span(start: f32, end: f32, cell_start: f32) -> Self {
+        let cell_end = cell_start + 1.0;
+        let covered_start = start.max(cell_start);
+        let covered_end = end.min(cell_end);
+
+        let covers_whole_cell =
+            covered_start <= cell_start + f32::EPSILON && covered_end >= cell_end - f32::EPSILON;
+        if covers_whole_cell {
+            return Self::Full;
+        }
+
+        let amount = eighths(covered_end - covered_start);
+        if covered_start <= cell_start + f32::EPSILON {
+            Self::Leading(amount)
+        } else {
+            Self::Trailing(amount)
+        }
+    }
+}
+
+/// Returns the unit terminal cells touched by a span along either axis.
+fn covered_cells(start: f32, end: f32) -> std::ops::RangeInclusive<i16> {
+    let start = start.floor() as i16;
+    let end = (end.ceil() as i16 - 1).max(start);
+    start..=end
+}
+
+/// Returns whether one unit terminal cell overlaps a covered span.
+fn cell_overlaps(cell_start: f32, span_start: f32, span_end: f32) -> bool {
+    let cell_end = cell_start + 1.0;
+    cell_start < span_end && cell_end > span_start
+}
+
+/// Quantizes fractional terminal-cell coverage to the available eighth-block resolution.
+fn eighths(amount: f32) -> u8 {
+    (amount.clamp(0.0, 1.0) * 8.0).round() as u8
+}
+
+/// Draws one moving end after establishing both cells' complete underlay surfaces.
+///
+/// Non-adjacent or unchanged points fall back to one stable cell. This covers initial frames and
+/// avoids applying fractional geometry to malformed interpolation pairs.
+fn render_moving_segment(buf: &mut Buffer, board_x: u16, board_y: u16, motion: EndMotion) {
+    render_moving_underlays(buf, board_x, board_y, motion);
+
+    match (
+        motion.current.x - motion.previous.x,
+        motion.current.y - motion.previous.y,
+    ) {
+        (-1 | 1, 0) => render_horizontal_segment(buf, board_x, board_y, motion),
+        (0, -1 | 1) => render_vertical_segment(buf, board_x, board_y, motion),
+        _ => render_snake_cell(buf, board_x, board_y, motion.color, motion.current),
+    }
+}
+
+/// Restores both logical cells before partial glyphs overwrite the moving rectangle.
+///
+/// Ratatui uses frame diffs, so repainting complete underlays prevents stale glyphs or colors from
+/// a wider previous fraction from surviving into the next frame.
+fn render_moving_underlays(buf: &mut Buffer, board_x: u16, board_y: u16, motion: EndMotion) {
+    render_underlay_cell(
+        buf,
+        board_x,
+        board_y,
+        motion.previous,
+        motion.previous_underlay,
+    );
+    render_underlay_cell(
+        buf,
+        board_x,
+        board_y,
+        motion.current,
+        motion.current_underlay,
+    );
+}
+
+/// Converts horizontal interpolation into terminal-column coverage and underlays.
+fn render_horizontal_segment(buf: &mut Buffer, board_x: u16, board_y: u16, motion: EndMotion) {
+    let cell_width = f32::from(TERMINAL_COLUMNS_PER_CELL);
+    let previous_left = motion.previous.x as f32 * cell_width;
+    let current_left = motion.current.x as f32 * cell_width;
+    let left = previous_left + (current_left - previous_left) * motion.progress;
+    let right = left + cell_width;
+    let previous_right = previous_left + cell_width;
+    let terminal_y = board_y + motion.previous.y.max(0) as u16;
+
+    for column in covered_cells(left, right) {
+        let coverage = Coverage::for_span(left, right, column as f32);
+        let underlay = if cell_overlaps(column as f32, previous_left, previous_right) {
+            motion.previous_underlay
+        } else {
+            motion.current_underlay
+        };
+        let terminal_x = board_x + column.max(0) as u16;
+        render_horizontal_coverage(
+            buf,
+            terminal_x,
+            terminal_y,
+            coverage,
+            motion.color,
+            underlay,
+        );
+    }
+}
+
+/// Converts vertical interpolation into terminal-row coverage for both wide-cell columns.
+fn render_vertical_segment(buf: &mut Buffer, board_x: u16, board_y: u16, motion: EndMotion) {
+    let previous_top = motion.previous.y as f32;
+    let current_top = motion.current.y as f32;
+    let top = previous_top + (current_top - previous_top) * motion.progress;
+    let bottom = top + 1.0;
+    let previous_bottom = previous_top + 1.0;
+    let terminal_x = board_x + motion.previous.x.max(0) as u16 * TERMINAL_COLUMNS_PER_CELL;
+
+    for row in covered_cells(top, bottom) {
+        let coverage = Coverage::for_span(top, bottom, row as f32);
+        let underlay = if cell_overlaps(row as f32, previous_top, previous_bottom) {
+            motion.previous_underlay
+        } else {
+            motion.current_underlay
+        };
+        let terminal_y = board_y + row.max(0) as u16;
+        for column in terminal_x..terminal_x + TERMINAL_COLUMNS_PER_CELL {
+            render_vertical_coverage(buf, column, terminal_y, coverage, motion.color, underlay);
+        }
+    }
+}
+
+/// Maps axis-neutral leading and trailing coverage to left and right block glyphs.
+fn render_horizontal_coverage(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    coverage: Coverage,
+    color: Color,
+    underlay: Underlay,
+) {
+    match coverage {
+        Coverage::Full => render_full_cell(buf, x, y, color),
+        Coverage::Leading(amount) => render_left_fraction(buf, x, y, amount, color, underlay),
+        Coverage::Trailing(amount) => render_right_fraction(buf, x, y, amount, color, underlay),
+    }
+}
+
+/// Paints one vertical coverage case into one of the logical cell's two terminal columns.
+fn render_vertical_coverage(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    coverage: Coverage,
+    color: Color,
+    underlay: Underlay,
+) {
+    match coverage {
+        Coverage::Full => render_full_cell(buf, x, y, color),
+        Coverage::Leading(amount) => render_top_fraction(buf, x, y, amount, color, underlay),
+        Coverage::Trailing(amount) => {
+            render_bottom_fraction(buf, x, y, amount, color, underlay);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::buffer::Buffer;
+
+    use super::{render_moving_snake_head, render_moving_snake_tail, render_snake};
+    use crate::{
+        geometry::{Board, Direction, Point},
+        snake::Snake,
+        terminal_cells::{BOARD_BACKGROUND, BOARD_BACKGROUND_ALT, BODY_COLOR, HEAD_COLOR},
+    };
+
+    #[test]
+    fn coverage_tracks_leading_full_and_trailing_cells() {
+        assert_eq!(
+            super::Coverage::for_span(0.25, 2.25, 0.0),
+            super::Coverage::Trailing(6)
+        );
+        assert_eq!(
+            super::Coverage::for_span(0.25, 2.25, 1.0),
+            super::Coverage::Full
+        );
+        assert_eq!(
+            super::Coverage::for_span(0.25, 2.25, 2.0),
+            super::Coverage::Leading(2)
+        );
+    }
+
+    #[test]
+    fn fractions_round_to_terminal_block_steps() {
+        assert_eq!(super::eighths(0.0), 0);
+        assert_eq!(super::eighths(0.125), 1);
+        assert_eq!(super::eighths(0.5), 4);
+        assert_eq!(super::eighths(1.0), 8);
+    }
+
+    #[test]
+    fn moving_tail_paints_the_whole_current_tail_underlay() {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 4, 1));
+
+        render_moving_snake_tail(&mut buffer, 0, 0, Point::new(0, 0), Point::new(1, 0), 0.25);
+
+        assert_eq!(buffer[(3, 0)].symbol(), "█");
+        assert_eq!(buffer[(3, 0)].style().fg, Some(BODY_COLOR));
+    }
+
+    #[test]
+    fn moving_head_reveals_body_without_a_different_colored_gap() {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 4, 1));
+
+        render_moving_snake_head(&mut buffer, 0, 0, Point::new(0, 0), Point::new(1, 0), 0.25);
+
+        assert_eq!(buffer[(0, 0)].symbol(), "▌");
+        assert_eq!(buffer[(0, 0)].style().fg, Some(BODY_COLOR));
+        assert_eq!(buffer[(0, 0)].style().bg, Some(HEAD_COLOR));
+        assert_eq!(buffer[(1, 0)].style().fg, Some(HEAD_COLOR));
+    }
+
+    #[test]
+    fn moving_tail_reveals_the_previous_cell_board_background() {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 4, 1));
+
+        render_moving_snake_tail(&mut buffer, 0, 0, Point::new(1, 0), Point::new(0, 0), 0.25);
+
+        assert_eq!(buffer[(3, 0)].style().bg, Some(BOARD_BACKGROUND_ALT));
+    }
+
+    #[test]
+    fn vertical_tail_uses_partial_height_blocks() {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 2, 2));
+
+        render_moving_snake_tail(&mut buffer, 0, 0, Point::new(0, 0), Point::new(0, 1), 0.25);
+
+        assert_eq!(buffer[(0, 0)].symbol(), "▆");
+        assert_eq!(buffer[(1, 0)].symbol(), "▆");
+        assert_eq!(buffer[(0, 0)].style().fg, Some(BODY_COLOR));
+        assert_eq!(buffer[(0, 0)].style().bg, Some(BOARD_BACKGROUND));
+    }
+
+    #[test]
+    fn growth_keeps_the_new_tail_as_a_stable_body_cell() {
+        let mut snake = Snake::new(Board::new(24, 20));
+        snake.replace_segments_for_test(
+            std::collections::VecDeque::from([Point::new(1, 0), Point::new(0, 0)]),
+            Direction::Right,
+        );
+        snake.advance(Point::new(2, 0), true);
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 6, 1));
+
+        render_snake(
+            &snake,
+            0.5,
+            ratatui::layout::Rect::new(0, 0, 6, 1),
+            &mut buffer,
+        );
+
+        assert_eq!(buffer[(0, 0)].symbol(), "█");
+        assert_eq!(buffer[(1, 0)].symbol(), "█");
+        assert_eq!(buffer[(0, 0)].style().fg, Some(BODY_COLOR));
+    }
+}

--- a/examples/snake/terminal.rs
+++ b/examples/snake/terminal.rs
@@ -1,0 +1,160 @@
+//! Terminal layout and rendering.
+//!
+//! [`crate::playfield`] owns terminal-size policy. This module performs the other half of the
+//! `bevy_ratatui` integration: [`draw_terminal`] projects [`Game`] into Ratatui cells.
+//!
+//! [`draw_terminal`] borrows [`RatatuiContext`], calls `draw`, and renders directly into the
+//! frame buffer. The module is otherwise a projection layer: it reads [`Game`] and writes terminal
+//! cells, but it does not mutate game rules. [`crate::game_loop::sync_playfield`] updates the
+//! shared playfield before drawing so the rule layer already knows the active board.
+//! This separation keeps Ratatui's immediate-mode rendering from becoming an implicit second update
+//! loop.
+//!
+//! The playfield uses [`crate::terminal_cells`] to render each logical [`Point`] as two
+//! side-by-side terminal cells. That keeps the arena readable while compensating for terminal
+//! cells that are usually taller than they are wide.
+//!
+//! Smooth movement is a rendering concern, not a rule concern. The head and tail are drawn between
+//! logical movement ticks, using partial terminal-cell block glyphs. The middle of the body is
+//! rendered on stable board cells so turns keep a consistent corner shape instead of flickering as
+//! adjacent body segments round through different sub-cell positions.
+
+use bevy::prelude::*;
+use bevy_ratatui::RatatuiContext;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Direction as LayoutDirection, Layout, Margin, Rect},
+    style::{Color, Style},
+    widgets::{Block, Borders, Widget},
+};
+
+use crate::{
+    game::{Game, GameStatus},
+    game_loop::GameTiming,
+    geometry::Point,
+    hud::{render_controls, render_hud, render_overlay, render_too_small},
+    playfield::{CONTROLS_HEIGHT, HUD_HEIGHT, MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH, Playfield},
+    snake_rendering::render_snake,
+    terminal_cells::{
+        BOARD_BACKGROUND, TERMINAL_COLUMNS_PER_CELL, render_background_cell, render_food_cell,
+    },
+};
+
+/// Border color separating collision bounds from the checker background.
+const WALL_COLOR: Color = Color::Rgb(66, 120, 91);
+
+/// Draws the current [`Game`] resource through [`RatatuiContext`].
+///
+/// Returning Bevy's `Result` allows terminal draw failures to propagate through the system runner.
+/// The closure receives the current Ratatui frame and writes widgets into its buffer; because this
+/// system runs in `PostUpdate`, it observes all chained game-loop changes from the same app frame.
+/// [`Playfield`] supplies the same availability decision that gated simulation during update.
+pub fn draw_terminal(
+    mut context: ResMut<RatatuiContext>,
+    game: Res<Game>,
+    timing: Res<GameTiming>,
+    playfield: Res<Playfield>,
+) -> Result {
+    let playfield_available = playfield.is_available();
+    context.draw(|frame| {
+        let area = frame.area();
+        render_game(
+            game.as_ref(),
+            timing.movement_progress(),
+            timing.crash_grace_active(),
+            playfield_available,
+            area,
+            frame.buffer_mut(),
+        );
+    })?;
+
+    Ok(())
+}
+
+/// Projects one complete game frame using the board availability synchronized during `Update`.
+fn render_game(
+    game: &Game,
+    movement_progress: f32,
+    crash_grace_active: bool,
+    playfield_available: bool,
+    area: Rect,
+    buf: &mut Buffer,
+) {
+    if !playfield_available {
+        render_too_small(area, buf, MIN_TERMINAL_WIDTH, MIN_TERMINAL_HEIGHT);
+        return;
+    }
+
+    let layout = Layout::default()
+        .direction(LayoutDirection::Vertical)
+        .constraints([
+            Constraint::Length(HUD_HEIGHT),
+            Constraint::Min(0),
+            Constraint::Length(CONTROLS_HEIGHT),
+        ])
+        .split(area);
+
+    render_hud(game, crash_grace_active, layout[0], buf);
+    render_board(game, movement_progress, layout[1], buf);
+    render_controls(layout[2], buf);
+
+    match game.status() {
+        GameStatus::Paused => render_overlay("Paused", "Press Space or P to resume", area, buf),
+        GameStatus::GameOver => {
+            render_overlay("Game over", "Press R to restart or Q to quit", area, buf)
+        }
+        GameStatus::Playing => {}
+    }
+}
+
+/// Paints the bordered playfield before layering food and snake cells over its background.
+fn render_board(game: &Game, movement_progress: f32, area: Rect, buf: &mut Buffer) {
+    Block::default()
+        .title(" Snake ")
+        .borders(Borders::ALL)
+        .border_style(Style::new().fg(WALL_COLOR))
+        .style(Style::new().bg(BOARD_BACKGROUND))
+        .render(area, buf);
+
+    let board = area.inner(Margin {
+        horizontal: 1,
+        vertical: 1,
+    });
+
+    // Each logical game cell renders as two terminal columns. This keeps the board readable on
+    // ordinary terminals while avoiding the tall-cell feel of a single-column grid.
+    let game_board = game.board();
+    for y in 0..game_board.height() {
+        for x in 0..game_board.width() {
+            let column = board.x + x as u16 * TERMINAL_COLUMNS_PER_CELL;
+            let point = Point::new(x, y);
+            render_background_cell(buf, column, board.y + y as u16, point);
+            if Some(point) == game.food() {
+                render_food_cell(buf, column, board.y + y as u16, point);
+            }
+        }
+    }
+
+    render_snake(game.snake(), movement_progress, board, buf);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_playfield_uses_fallback_even_when_frame_is_large() {
+        let area = Rect::new(0, 0, 100, 40);
+        let mut buffer = Buffer::empty(area);
+
+        render_game(&Game::new(), 0.0, false, false, area, &mut buffer);
+
+        let rendered = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .concat();
+        assert!(rendered.contains("Terminal too small"));
+    }
+}

--- a/examples/snake/terminal_cells.rs
+++ b/examples/snake/terminal_cells.rs
@@ -1,0 +1,368 @@
+//! Drawing primitives for logical snake cells.
+//!
+//! This module owns the conversion from one logical board cell to terminal cells. Higher-level
+//! modules decide *which* cells to draw; this module decides how background, food, stable body
+//! cells, moving-segment underlays, and colored partial glyphs are painted. Keeping color inversion
+//! here beside stable-cell painting makes every terminal-cell foreground/background rule locally
+//! visible. Unicode glyph lookup stays here because these glyphs are the terminal representation
+//! selected by the fraction-painting functions below.
+
+use ratatui::{
+    buffer::Buffer,
+    style::{Color, Modifier, Style},
+};
+
+use crate::geometry::Point;
+
+/// Terminal columns used by one square-looking logical game cell.
+///
+/// This module owns the logical-to-terminal projection, so sizing, stable rendering, and animated
+/// rendering all use this single definition.
+pub const TERMINAL_COLUMNS_PER_CELL: u16 = 2;
+/// Primary low-contrast playfield background.
+pub const BOARD_BACKGROUND: Color = Color::Rgb(3, 10, 8);
+/// Alternate checker cell, kept close to the primary color to avoid visual noise during movement.
+pub const BOARD_BACKGROUND_ALT: Color = Color::Rgb(4, 12, 9);
+/// Brighter snake color that keeps the moving head distinguishable from its body underlay.
+pub const HEAD_COLOR: Color = Color::Rgb(189, 255, 128);
+/// Shared body and connection-underlay color.
+pub const BODY_COLOR: Color = Color::Rgb(88, 214, 141);
+/// Food foreground hint for terminals that honor emoji styling.
+pub const FOOD_COLOR: Color = Color::Rgb(255, 92, 92);
+
+/// Surface visible behind a partial block glyph.
+///
+/// Unicode gives left and lower partial block glyphs. Right and top fractions are represented by
+/// swapping foreground and background colors, so the underlay must be explicit instead of inferred
+/// from the current buffer cell.
+#[derive(Clone, Copy, Debug)]
+pub enum Underlay {
+    /// Empty board surface for one logical board cell.
+    Board(Color),
+    /// Stable snake-body surface.
+    Body,
+}
+
+impl Underlay {
+    /// Returns an empty board underlay for `point`.
+    pub fn board(point: Point) -> Self {
+        Self::Board(background_for(point))
+    }
+
+    /// Returns the terminal color for this underlay.
+    pub fn color(self) -> Color {
+        match self {
+            Self::Board(color) => color,
+            Self::Body => BODY_COLOR,
+        }
+    }
+}
+
+/// Renders the background for one logical board cell.
+pub fn render_background_cell(buf: &mut Buffer, x: u16, y: u16, point: Point) {
+    fill_board_cell(buf, x, y, background_for(point));
+}
+
+/// Renders food as a single double-width emoji.
+///
+/// The second cell is left blank so terminals that treat the emoji as width two have room for it.
+pub fn render_food_cell(buf: &mut Buffer, x: u16, y: u16, point: Point) {
+    let background = background_for(point);
+    buf[(x, y)].set_symbol("🍎").set_style(
+        Style::new()
+            .fg(FOOD_COLOR)
+            .bg(background)
+            .add_modifier(Modifier::BOLD),
+    );
+    for column in x + 1..x + TERMINAL_COLUMNS_PER_CELL {
+        buf[(column, y)]
+            .set_symbol(" ")
+            .set_style(Style::new().bg(background));
+    }
+}
+
+/// Renders a left-side horizontal fraction over an explicit underlay.
+pub fn render_left_fraction(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    amount: u8,
+    fill: Color,
+    underlay: Underlay,
+) {
+    if amount == 0 {
+        return;
+    }
+
+    if amount >= 8 {
+        render_full_cell(buf, x, y, fill);
+        return;
+    }
+
+    buf[(x, y)]
+        .set_symbol(horizontal_block(amount))
+        .set_style(partial_style(fill, underlay.color()));
+}
+
+/// Renders a right-side fraction by swapping glyph foreground and background.
+///
+/// Unicode provides left eighth blocks but no matching right eighth blocks. The complementary left
+/// glyph therefore paints the underlay while the background color becomes the visible snake edge.
+pub fn render_right_fraction(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    amount: u8,
+    fill: Color,
+    underlay: Underlay,
+) {
+    if amount == 0 {
+        return;
+    }
+
+    if amount >= 8 {
+        render_full_cell(buf, x, y, fill);
+        return;
+    }
+
+    buf[(x, y)]
+        .set_symbol(horizontal_block(8 - amount))
+        .set_style(partial_style(underlay.color(), fill));
+}
+
+/// Renders a top-side fraction using the complement of a lower block glyph.
+pub fn render_top_fraction(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    amount: u8,
+    fill: Color,
+    underlay: Underlay,
+) {
+    if amount == 0 {
+        return;
+    }
+
+    if amount >= 8 {
+        render_full_cell(buf, x, y, fill);
+        return;
+    }
+
+    buf[(x, y)]
+        .set_symbol(vertical_block(8 - amount))
+        .set_style(partial_style(underlay.color(), fill));
+}
+
+/// Renders a bottom-side vertical fraction over an explicit underlay.
+pub fn render_bottom_fraction(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    amount: u8,
+    fill: Color,
+    underlay: Underlay,
+) {
+    if amount == 0 {
+        return;
+    }
+
+    if amount >= 8 {
+        render_full_cell(buf, x, y, fill);
+        return;
+    }
+
+    buf[(x, y)]
+        .set_symbol(vertical_block(amount))
+        .set_style(partial_style(fill, underlay.color()));
+}
+
+/// Renders one stable snake segment on its logical board cell.
+pub fn render_snake_cell(buf: &mut Buffer, board_x: u16, board_y: u16, color: Color, point: Point) {
+    let terminal_x = board_x + point.x.max(0) as u16 * TERMINAL_COLUMNS_PER_CELL;
+    let terminal_y = board_y + point.y.max(0) as u16;
+    fill_snake_cell(buf, terminal_x, terminal_y, color);
+}
+
+/// Renders the full two-column underlay for a moving head or tail.
+pub fn render_underlay_cell(
+    buf: &mut Buffer,
+    board_x: u16,
+    board_y: u16,
+    point: Point,
+    underlay: Underlay,
+) {
+    let terminal_x = board_x + point.x.max(0) as u16 * TERMINAL_COLUMNS_PER_CELL;
+    let terminal_y = board_y + point.y.max(0) as u16;
+
+    match underlay {
+        Underlay::Body => fill_snake_cell(buf, terminal_x, terminal_y, BODY_COLOR),
+        Underlay::Board(color) => fill_board_cell(buf, terminal_x, terminal_y, color),
+    }
+}
+
+/// Renders one full terminal cell shared by stable snake cells and complete fractional coverage.
+///
+/// Keeping both paths on this primitive guarantees that interpolation reaching a cell boundary has
+/// the same foreground and background colors as the stable frame that follows it.
+pub fn render_full_cell(buf: &mut Buffer, terminal_x: u16, terminal_y: u16, color: Color) {
+    let style = Style::new().fg(color).bg(BOARD_BACKGROUND);
+
+    buf[(terminal_x, terminal_y)]
+        .set_symbol("█")
+        .set_style(style);
+}
+
+/// Builds a color-only style used for full and partial snake cells.
+///
+/// Right and top fractions swap foreground and background to synthesize missing Unicode glyphs.
+/// Text modifiers would therefore apply to the snake on some edges and its underlay on others. The
+/// explicit head and body colors carry visual identity consistently without modifiers.
+pub fn partial_style(fg: Color, bg: Color) -> Style {
+    Style::new().fg(fg).bg(bg)
+}
+
+/// Fills both terminal columns that represent one logical snake cell.
+fn fill_snake_cell(buf: &mut Buffer, terminal_x: u16, terminal_y: u16, color: Color) {
+    for column in terminal_x..terminal_x + TERMINAL_COLUMNS_PER_CELL {
+        render_full_cell(buf, column, terminal_y, color);
+    }
+}
+
+/// Clears both terminal columns to one board color, including any prior wide glyph.
+fn fill_board_cell(buf: &mut Buffer, terminal_x: u16, terminal_y: u16, color: Color) {
+    let style = Style::new().bg(color);
+    for column in terminal_x..terminal_x + TERMINAL_COLUMNS_PER_CELL {
+        buf[(column, terminal_y)].set_symbol(" ").set_style(style);
+    }
+}
+
+/// Returns the subtle checker color for one logical point.
+///
+/// Food and partial moving cells must use this same function; otherwise their explicit terminal
+/// backgrounds create rectangular patches against alternate cells.
+fn background_for(point: Point) -> Color {
+    if (point.x + point.y) % 2 == 0 {
+        BOARD_BACKGROUND
+    } else {
+        BOARD_BACKGROUND_ALT
+    }
+}
+
+/// Returns a left-side block glyph for `amount` eighths.
+fn horizontal_block(amount: u8) -> &'static str {
+    match amount {
+        0 => " ",
+        1 => "▏",
+        2 => "▎",
+        3 => "▍",
+        4 => "▌",
+        5 => "▋",
+        6 => "▊",
+        7 => "▉",
+        _ => "█",
+    }
+}
+
+/// Returns a lower-side block glyph for `amount` eighths.
+fn vertical_block(amount: u8) -> &'static str {
+    match amount {
+        0 => " ",
+        1 => "▁",
+        2 => "▂",
+        3 => "▃",
+        4 => "▄",
+        5 => "▅",
+        6 => "▆",
+        7 => "▇",
+        _ => "█",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_body_uses_the_same_solid_surface_as_partial_underlay() {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
+
+        render_full_cell(&mut buffer, 0, 0, BODY_COLOR);
+
+        assert_eq!(buffer[(0, 0)].symbol(), "█");
+        assert_eq!(buffer[(0, 0)].style().fg, Some(BODY_COLOR));
+        assert_eq!(buffer[(0, 0)].style().add_modifier, Modifier::empty());
+
+        let partial = partial_style(BODY_COLOR, BOARD_BACKGROUND);
+        assert_eq!(partial.add_modifier, Modifier::empty());
+    }
+
+    #[test]
+    fn board_underlay_uses_the_logical_cell_background() {
+        assert_eq!(Underlay::board(Point::new(0, 0)).color(), BOARD_BACKGROUND);
+        assert_eq!(
+            Underlay::board(Point::new(1, 0)).color(),
+            BOARD_BACKGROUND_ALT
+        );
+    }
+
+    #[test]
+    fn food_preserves_the_background_of_its_logical_cell() {
+        let width = TERMINAL_COLUMNS_PER_CELL;
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, width, 1));
+
+        render_food_cell(&mut buffer, 0, 0, Point::new(1, 0));
+
+        assert_eq!(buffer[(0, 0)].style().bg, Some(BOARD_BACKGROUND_ALT));
+        assert_eq!(buffer[(1, 0)].style().bg, Some(BOARD_BACKGROUND_ALT));
+    }
+
+    #[test]
+    fn right_fraction_can_leave_body_colored_underlay() {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
+
+        render_right_fraction(&mut buffer, 0, 0, 2, HEAD_COLOR, Underlay::Body);
+
+        assert_eq!(buffer[(0, 0)].symbol(), "▊");
+        assert_eq!(buffer[(0, 0)].style().fg, Some(BODY_COLOR));
+        assert_eq!(buffer[(0, 0)].style().bg, Some(HEAD_COLOR));
+    }
+
+    #[test]
+    fn left_fraction_uses_body_over_background() {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
+
+        render_left_fraction(
+            &mut buffer,
+            0,
+            0,
+            2,
+            BODY_COLOR,
+            Underlay::board(Point::new(0, 0)),
+        );
+
+        assert_eq!(buffer[(0, 0)].symbol(), "▎");
+        assert_eq!(buffer[(0, 0)].style().fg, Some(BODY_COLOR));
+        assert_eq!(buffer[(0, 0)].style().bg, Some(BOARD_BACKGROUND));
+    }
+
+    #[test]
+    fn left_fraction_can_leave_body_colored_underlay() {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
+
+        render_left_fraction(&mut buffer, 0, 0, 2, BODY_COLOR, Underlay::Body);
+
+        assert_eq!(buffer[(0, 0)].symbol(), "▎");
+        assert_eq!(buffer[(0, 0)].style().fg, Some(BODY_COLOR));
+        assert_eq!(buffer[(0, 0)].style().bg, Some(BODY_COLOR));
+    }
+
+    #[test]
+    fn block_glyphs_cover_each_axis_in_eighths() {
+        assert_eq!(horizontal_block(1), "▏");
+        assert_eq!(horizontal_block(4), "▌");
+        assert_eq!(horizontal_block(8), "█");
+        assert_eq!(vertical_block(1), "▁");
+        assert_eq!(vertical_block(4), "▄");
+        assert_eq!(vertical_block(8), "█");
+    }
+}

--- a/src/crossterm_context/event.rs
+++ b/src/crossterm_context/event.rs
@@ -51,39 +51,56 @@ impl Plugin for EventPlugin {
             .add_message::<FocusMessage>()
             .add_message::<ResizeMessage>()
             .add_message::<PasteMessage>()
-            .add_message::<CrosstermMessage>()
-            .configure_sets(
-                Update,
-                (
-                    InputSet::Pre,
-                    InputSet::EmitCrossterm,
-                    InputSet::CheckEmulation,
-                    InputSet::EmitBevy,
-                    InputSet::Post,
-                )
-                    .chain(),
-            )
-            .add_systems(
-                PreUpdate,
-                crossterm_event_system.in_set(InputSet::EmitCrossterm),
-            );
+            .add_message::<CrosstermMessage>();
+
+        configure_input_sets(app);
+        app.add_systems(
+            PreUpdate,
+            crossterm_event_system.in_set(InputSet::EmitCrossterm),
+        );
 
         if self.control_c_interrupt {
-            app.add_systems(Update, control_c_interrupt_system.in_set(InputSet::Post));
+            app.add_systems(PreUpdate, control_c_interrupt_system.in_set(InputSet::Post));
         }
     }
 }
 
-/// InputSet defines when the input messages are emitted.
+/// Orders the public input extension points in the schedule that emits terminal messages.
+fn configure_input_sets(app: &mut App) {
+    app.configure_sets(
+        PreUpdate,
+        (
+            InputSet::Pre,
+            InputSet::EmitCrossterm,
+            InputSet::CheckEmulation,
+            InputSet::EmitBevy,
+            InputSet::Post,
+        )
+            .chain(),
+    );
+}
+
+/// Input-processing phases ordered within [`PreUpdate`].
+///
+/// Bevy configures system-set ordering separately for each schedule. Systems using these extension
+/// points must therefore be added to `PreUpdate` for the ordering below to apply:
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_ratatui::event::{InputSet, KeyMessage};
+/// # fn handle_keys(_: MessageReader<KeyMessage>) {}
+/// # let mut app = App::new();
+/// app.add_systems(PreUpdate, handle_keys.in_set(InputSet::Post));
+/// ```
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
 pub enum InputSet {
     /// Run before any input messages are emitted.
     Pre,
     /// Emit the crossterm messages.
     EmitCrossterm,
-    /// Check for emulation
+    /// Check for emulation.
     CheckEmulation,
-    /// Emit the bevy messages if [crate::input_forwarding::KeyboardPlugin] has been added.
+    /// Emit the bevy messages if [`crate::translation::TranslationPlugin`] has been added.
     EmitBevy,
     /// Run after all input messages are emitted.
     Post,
@@ -164,5 +181,59 @@ fn control_c_interrupt_system(
         {
             exit.write_default();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Execution trace used to verify the schedule contract exposed by [`InputSet`].
+    #[derive(Default, Resource)]
+    struct InputOrder(Vec<InputSet>);
+
+    #[test]
+    fn input_sets_run_in_order_during_pre_update() {
+        let mut app = App::new();
+        configure_input_sets(&mut app);
+        app.init_resource::<InputOrder>()
+            .add_systems(PreUpdate, record_pre.in_set(InputSet::Pre))
+            .add_systems(PreUpdate, record_crossterm.in_set(InputSet::EmitCrossterm))
+            .add_systems(PreUpdate, record_emulation.in_set(InputSet::CheckEmulation))
+            .add_systems(PreUpdate, record_bevy.in_set(InputSet::EmitBevy))
+            .add_systems(PreUpdate, record_post.in_set(InputSet::Post));
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<InputOrder>().0,
+            [
+                InputSet::Pre,
+                InputSet::EmitCrossterm,
+                InputSet::CheckEmulation,
+                InputSet::EmitBevy,
+                InputSet::Post,
+            ]
+        );
+    }
+
+    fn record_pre(mut order: ResMut<InputOrder>) {
+        order.0.push(InputSet::Pre);
+    }
+
+    fn record_crossterm(mut order: ResMut<InputOrder>) {
+        order.0.push(InputSet::EmitCrossterm);
+    }
+
+    fn record_emulation(mut order: ResMut<InputOrder>) {
+        order.0.push(InputSet::CheckEmulation);
+    }
+
+    fn record_bevy(mut order: ResMut<InputOrder>) {
+        order.0.push(InputSet::EmitBevy);
+    }
+
+    fn record_post(mut order: ResMut<InputOrder>) {
+        order.0.push(InputSet::Post);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! # Input Forwarding
 //!
 //! The terminal input can be forwarded to the bevy input system. See the
-//! [input_forwarding] module documentation for details.
+//! [`translation`] module documentation for details.
 //!
 //! [Bevy]: https://bevyengine.org
 //! [Ratatui]: https://ratatui.rs


### PR DESCRIPTION
## Summary

- add a multi-file terminal Snake example using Bevy resources, messages, systems, and Ratatui rendering
- include terminal-sized boards, HUD and overlays, buffered turns, Nokia-inspired crash grace, level-based speed, high score, restart, and smooth partial-block head and tail movement
- preserve interpolation through pause and collision, suspend simulation while the terminal is too small, and process a bounded number of elapsed movement steps after scheduler stalls
- document module ownership, gameplay policies, terminal-cell rendering constraints, invariants, and edge cases near the items that implement them
- fix nearby Rustdoc links that pointed at the old input translation path

## Validation

- `cargo fmt --all --check`
- `cargo check --example snake`
- `cargo test --example snake` (39 tests)
- `cargo check --workspace --all-targets`
- `RUSTDOCFLAGS='-D warnings' cargo doc --example snake --no-deps`
- `markdownlint-cli2 --config ~/.markdownlint-cli2.yaml README.md examples/snake/README.md`
- small-screen Betamax smoke recording with the real terminal backend

## Notes

The movement timer runs independently from the 60 FPS render loop. It catches up at most four logical steps after a delayed frame, freezes during explicit pause or terminal-size suspension, and uses a separate 80 ms crash-grace timer.
