### PR TITLE
Don't restore the terminal in the eyre hook.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4100,9 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking"
@@ -4707,9 +4707,9 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["cli", "ratatui", "terminal", "tui", "bevy"]
 [dependencies]
 bevy = { version = "0.18", default-features = false }
 bitflags = "2.8.0"
-color-eyre = "0.6.3"
 ratatui = { version = "0.30.0", default-features = false }
 soft_ratatui = { version = "0.1", optional = true }
 tracing = "0.1.44"
 
 [dev-dependencies]
+color-eyre = "0.6.3"
 rand = "0.9.3"
 bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
 ratatui = { version = "0.30.0", default-features = false, features = [

--- a/examples/bevy_keys.rs
+++ b/examples/bevy_keys.rs
@@ -14,7 +14,9 @@ use bevy_ratatui::{
 use ratatui::crossterm::event::KeyEventKind;
 use ratatui::text::Text;
 
-fn main() {
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let wait_duration = std::time::Duration::from_secs_f64(1. / 60.); // 60 FPS
     App::new()
         .add_plugins(RatatuiPlugins {
@@ -33,6 +35,8 @@ fn main() {
         .add_systems(Update, draw_scene_system)
         .add_systems(Update, hotkeys)
         .run();
+
+    Ok(())
 }
 
 #[derive(Resource, Deref, DerefMut)]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -30,7 +30,9 @@ use ratatui::{
     widgets::WidgetRef,
 };
 
-fn main() {
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let mut app = App::new();
 
     #[cfg(not(feature = "windowed"))]
@@ -64,6 +66,8 @@ fn main() {
         .add_systems(OnEnter(AppState::Negative), start_background_color_timer)
         .add_systems(OnEnter(AppState::Positive), start_background_color_timer)
         .run();
+
+    Ok(())
 }
 
 fn ui_system(

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,7 +4,9 @@ use bevy_ratatui::{RatatuiContext, RatatuiPlugins};
 use ratatui::crossterm::event::KeyCode;
 use ratatui::text::Text;
 
-fn main() {
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
     App::new()
         .add_plugins((
             MinimalPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
@@ -15,6 +17,8 @@ fn main() {
         .add_systems(PreUpdate, input_system)
         .add_systems(Update, draw_system)
         .run();
+
+    Ok(())
 }
 
 fn draw_system(mut context: ResMut<RatatuiContext>) -> Result {

--- a/examples/kitty.rs
+++ b/examples/kitty.rs
@@ -6,7 +6,9 @@ use bevy_ratatui::{RatatuiContext, RatatuiPlugins, event::KeyMessage, kitty::Kit
 use ratatui::crossterm::event::KeyEventKind;
 use ratatui::text::Text;
 
-fn main() {
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let wait_duration = std::time::Duration::from_secs_f64(1. / 60.); // 60 FPS
     App::new()
         .add_plugins(RatatuiPlugins::default())
@@ -14,6 +16,8 @@ fn main() {
         .add_systems(PreUpdate, keyboard_input_system)
         .add_systems(Update, draw_scene_system)
         .run();
+
+    Ok(())
 }
 
 #[derive(Resource, Deref, DerefMut)]

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -6,7 +6,9 @@ use bevy_ratatui::{RatatuiContext, RatatuiPlugins, event::KeyMessage, event::Mou
 use rand::prelude::*;
 use ratatui::crossterm::event::MouseEventKind;
 
-fn main() {
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let wait_duration = std::time::Duration::from_secs_f64(1. / 60.); // 60 FPS
     App::new()
         .add_plugins(RatatuiPlugins {
@@ -19,6 +21,8 @@ fn main() {
         .add_systems(Update, (move_balls, bounce_balls.chain()))
         .add_systems(PostUpdate, draw_balls)
         .run();
+
+    Ok(())
 }
 
 fn keyboard_input_system(

--- a/examples/snake/main.rs
+++ b/examples/snake/main.rs
@@ -56,7 +56,9 @@ use terminal::draw_terminal;
 /// frame rate keeps terminal input and partial-cell rendering responsive, while
 /// [`game_loop::GameTiming`] demonstrates that application updates can use their own slower
 /// cadence.
-fn main() {
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let translate_input = translate_keyboard_input.in_set(InputSet::Post);
 
     App::new()
@@ -77,4 +79,6 @@ fn main() {
         )
         .add_systems(PostUpdate, draw_terminal)
         .run();
+
+    Ok(())
 }

--- a/src/crossterm_context/error.rs
+++ b/src/crossterm_context/error.rs
@@ -1,24 +1,19 @@
-//! Error handling for the app.
+//! Panic handling for the app.
 //!
-//! This module provides a plugin that sets up error handling for the app. It installs hooks for
-//! panic and error handling that restore the terminal before printing the panic or error message.
-//! This ensures that the error message is not messed up by the terminal state.
+//! This module provides a plugin that sets up panic handling for the app. It installs a hook for
+//! panic handling that restores the terminal before printing the panic. This ensures that the error
+//! message is not messed up by the terminal state.
 use std::panic;
 
 use bevy::prelude::*;
-use color_eyre::{
-    self,
-    config::{EyreHook, HookBuilder, PanicHook},
-    eyre,
-};
 
 use crate::RatatuiContext;
 
-/// A plugin that sets up error handling.
+/// A plugin that sets up panic handling.
 ///
-/// This plugin installs hooks for panic and error handling that restore the terminal before
-/// printing the panic or error message. This ensures that the error message is not messed up by the
-/// terminal state.
+/// This plugin installs a hook for panic handling that restores the terminal before printing the
+/// panic or error message. This ensures that the error message is not messed up by the terminal
+/// state.
 pub struct ErrorPlugin;
 
 impl Plugin for ErrorPlugin {
@@ -27,35 +22,16 @@ impl Plugin for ErrorPlugin {
     }
 }
 
-/// Installs hooks for panic and error handling.
+/// Installs a hook for panic handling.
 ///
-/// Makes the app resilient to panics and errors by restoring the terminal before printing the
-/// panic or error message. This prevents error messages from being messed up by the terminal
-/// state.
+/// Makes the app resilient to panics by restoring the terminal before printing the panic. This
+/// prevents error messages from being messed up by the terminal state.
 pub fn error_setup() -> Result {
-    let (panic_hook, eyre_hook) = HookBuilder::default().into_hooks();
-    set_panic_hook(panic_hook);
-    set_error_hook(eyre_hook)?;
-
-    Ok(())
-}
-
-/// Install a panic hook that restores the terminal before printing the panic.
-fn set_panic_hook(panic_hook: PanicHook) {
-    let panic_hook = panic_hook.into_panic_hook();
+    let panic_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {
         let _ = RatatuiContext::restore();
         panic_hook(panic_info);
     }));
-}
-
-/// Install an error hook that restores the terminal before printing the error.
-fn set_error_hook(eyre_hook: EyreHook) -> Result {
-    let eyre_hook = eyre_hook.into_eyre_hook();
-    eyre::set_hook(Box::new(move |error| {
-        let _ = RatatuiContext::restore();
-        eyre_hook(error)
-    }))?;
 
     Ok(())
 }


### PR DESCRIPTION
The eyre hook runs when converting errors into eyre reports, which can happen at any time (e.g. for showing a recoverable error to the user) and isn't only for panics.

On an actual panic, the panic hook already restores the terminal state before the panic is printed and it's not necessary to do it again; when AppExit is sent the cleanup plugin already restores the terminal state before any error is returned from main and printed by eyre.

So, there's no need to have a custom eyre hook to restore the terminal; move the dependency on color_eyre to dev dependencies and install it in each example to demonstrate the correct sequence (installing color_eyre first, before bevy_ratatui installs its own panic handler to restore the terminal).

See https://github.com/ratatui/ratatui/issues/1277 and https://github.com/eyre-rs/eyre/issues/184 for discussion of why this is correct and where a similar change was made in ratatui's own examples.