### PR TITLE
Fix double terminal restore on panic.

### DIFF
--- a/src/crossterm_context/context.rs
+++ b/src/crossterm_context/context.rs
@@ -1,4 +1,5 @@
 use std::io::{Stdout, stdout};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use bevy::prelude::*;
 
@@ -19,12 +20,18 @@ use super::mouse::MousePlugin;
 #[cfg(feature = "keyboard")]
 use super::translation::TranslationPlugin;
 
+static TERMINAL_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
 /// Ratatui context that will draw to the terminal buffer using crossterm.
 #[derive(Deref, DerefMut, Debug)]
 pub struct CrosstermContext(Terminal<CrosstermBackend<Stdout>>);
 
 impl TerminalContext<CrosstermBackend<Stdout>> for CrosstermContext {
     fn init() -> Result<Self> {
+        if TERMINAL_INITIALIZED.swap(true, Ordering::Relaxed) {
+            return Err("Only one CrosstermContext can exist at a time".into());
+        }
+
         let mut stdout = stdout();
         stdout.execute(EnterAlternateScreen)?;
         enable_raw_mode()?;
@@ -34,11 +41,13 @@ impl TerminalContext<CrosstermBackend<Stdout>> for CrosstermContext {
     }
 
     fn restore() -> Result<()> {
-        let mut stdout = stdout();
-        stdout
-            .execute(LeaveAlternateScreen)?
-            .execute(cursor::Show)?;
-        disable_raw_mode()?;
+        if TERMINAL_INITIALIZED.swap(false, Ordering::Relaxed) {
+            let mut stdout = stdout();
+            stdout
+                .execute(LeaveAlternateScreen)?
+                .execute(cursor::Show)?;
+            disable_raw_mode()?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
The panic hook restores the terminal so that the panic can be printed correctly, but when the world is destroyed during unwinding the CrosstermContext destructor restored the terminal a second time, which resulted in the cursor position being restored to the original location from when the alternate screen was originally entered, *before* the panic was printed, and the shell prompt then got printed over the top of the panic information.

Use an atomic boolean to track whether the terminal is currently in the "initialized" state so it can be restored exactly once regardless of how we exit. Creating two CrosstermContexts at the same time is now an error, since it doesn't make sense for the single terminal on stdout to be controlled by more than one thing.

Fixes #104